### PR TITLE
Remove default command from help

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ $ dokku plugin:install https://github.com/dokku/dokku-http-auth.git
 
 ```
 $ dokku http-auth:help
-    http-auth <app>                             Display the current HTTP auth status of app
     http-auth:add-user <app> <user> <password>  Add basic auth user to app
     http-auth:add-allowed-ip <app> <address>    Add allowed IP to basic auth bypass for an app
     http-auth:off <app>                         Disable HTTP auth for app

--- a/help-functions
+++ b/help-functions
@@ -27,7 +27,6 @@ help_desc
 fn-help-content() {
   declare desc="return help content"
   cat <<help_content
-    http-auth <app>, Display the current HTTP auth status of app
     http-auth:add-user <app> <user> <password>, Add basic auth user to app
     http-auth:add-allowed-ip <app> <address>, add allowed ip to basic auth bypass for an app
     http-auth:off <app>, Disable HTTP auth for app


### PR DESCRIPTION
It triggers the help command, not the command mentioned in the help.