### PR TITLE
Only enable basic auth if there are users

### DIFF
--- a/internal-functions
+++ b/internal-functions
@@ -48,11 +48,12 @@ fn-http-auth-template-config() {
   declare APP="$1"
   local APP_ROOT="$DOKKU_ROOT/$APP"
   local DOKKU_TEMPLATE="$PLUGIN_AVAILABLE_PATH/http-auth/templates/http-auth.conf"
+  local HAS_ALLOWED_USERS="$(test -s $APP_ROOT/htpasswd || echo "false")"
   local ALLOWED_IPS
 
   ALLOWED_IPS="$(fn-plugin-property-list-get "http-auth" "$APP" "allowed-ips" | xargs)"
   mkdir -p "$APP_ROOT/nginx.conf.d"
 
-  sigil -f "$DOKKU_TEMPLATE" APP_ROOT="$APP_ROOT" ALLOWED_IPS="$ALLOWED_IPS" | cat -s >"$APP_ROOT/nginx.conf.d/http-auth.conf"
+  sigil -f "$DOKKU_TEMPLATE" APP_ROOT="$APP_ROOT" ALLOWED_IPS="$ALLOWED_IPS" HAS_ALLOWED_USERS="$HAS_ALLOWED_USERS" | cat -s >"$APP_ROOT/nginx.conf.d/http-auth.conf"
   touch "$APP_ROOT/htpasswd"
 }

--- a/templates/http-auth.conf
+++ b/templates/http-auth.conf
@@ -4,7 +4,9 @@ satisfy any;
 allow {{ $allowed_ips }};
 {{ end }}
 deny all;
-
 {{ end }}
+
+{{ if $HAS_ALLOWED_USERS }}
 auth_basic           "Restricted";
 auth_basic_user_file {{ $.APP_ROOT }}/htpasswd;
+{{ end }}


### PR DESCRIPTION
This allows the plugin to function as a simple IP restriction filter.

Fixes #16

Untested, but should work :crossed_fingers: 