### PR TITLE
fix: correctly insert `auth_basic` block if there are users defined

### DIFF
--- a/internal-functions
+++ b/internal-functions
@@ -48,7 +48,7 @@ fn-http-auth-template-config() {
   declare APP="$1"
   local APP_ROOT="$DOKKU_ROOT/$APP"
   local DOKKU_TEMPLATE="$PLUGIN_AVAILABLE_PATH/http-auth/templates/http-auth.conf"
-  local HAS_ALLOWED_USERS="$(test -s $APP_ROOT/htpasswd || echo "false")"
+  local HAS_ALLOWED_USERS="$(test -s $APP_ROOT/htpasswd && echo "true")"
   local ALLOWED_IPS
 
   ALLOWED_IPS="$(fn-plugin-property-list-get "http-auth" "$APP" "allowed-ips" | xargs)"


### PR DESCRIPTION
`HAS_ALLOWED_USERS` variable was empty when `htpasswd` exists, which is falsey in sigil, and `"false"` when it does not exist, which is actually truthy in sigil, so the conditional in template worked the other way around. 

`auth_basic` section is was added to nginx config when it should be.

Fixes bug introduced in #22.