### PR TITLE
refactor: use path available to nginx process for htpasswd files

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ dokku http-auth:show-config node-js-app username
 
 ```
 auth_basic           "Restricted";
-auth_basic_user_file /home/dokku/node-js-app/htpasswd;
+auth_basic_user_file /etc/nginx/htpasswd/node-js-app;
 ```
 
 ### Displaying http auth reports for an app

--- a/bin/setup-htpasswd
+++ b/bin/setup-htpasswd
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+main() {
+    declare desc="copy htpasswd to nginx"
+    declare APP="$1"
+
+    cp "$DOKKU_LIB_ROOT/data/http-auth/$APP/htpasswd" "/etc/nginx/htpasswd/$APP"
+    chown "root:root" "/etc/nginx/htpasswd/$APP"
+}
+
+main "$@"

--- a/bin/teardown-htpasswd
+++ b/bin/teardown-htpasswd
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+main() {
+    declare desc="copy htpasswd to nginx"
+    declare APP="$1"
+
+    rm -f "/etc/nginx/htpasswd/$APP"
+}
+
+main "$@"

--- a/install
+++ b/install
@@ -11,6 +11,44 @@ trigger-http-auth-install() {
   if [[ -z "$(which mkpasswd 2>/dev/null)" ]]; then
     apt-get update && apt-get install -y whois
   fi
+
+  mkdir -p /etc/nginx/htpasswd/
+  mkdir -p "$DOKKU_LIB_ROOT/data/http-auth/"
+  chown "root:root" "/etc/nginx/htpasswd/"
+  chown "$DOKKU_SYSTEM_USER:$DOKKU_SYSTEM_GROUP" "$DOKKU_LIB_ROOT/data/http-auth/"
+
+  local reload_nginx=false
+  for app in $(dokku_apps "false" 2>/dev/null); do
+    if [[ ! -f "$DOKKU_ROOT/$app/htpasswd" ]]; then
+      continue
+    fi
+
+    mkdir -p "$DOKKU_LIB_ROOT/data/http-auth/$app"
+    chown "$DOKKU_SYSTEM_USER:$DOKKU_SYSTEM_GROUP" "$DOKKU_LIB_ROOT/data/http-auth/$app"
+
+    # migrate the htpasswd file to the new temp location
+    if [[ ! -f "$DOKKU_LIB_ROOT/data/http-auth/$app/htpasswd" ]] && [[ -f "$DOKKU_ROOT/$app/htpasswd" ]]; then
+      mv "$DOKKU_ROOT/$app/htpasswd" "$DOKKU_LIB_ROOT/data/http-auth/$app/htpasswd"
+    fi
+
+    touch "$DOKKU_LIB_ROOT/data/http-auth/$app/htpasswd"
+    chown "$DOKKU_SYSTEM_USER:$DOKKU_SYSTEM_GROUP" "$DOKKU_LIB_ROOT/data/http-auth/$app/htpasswd"
+
+    rm -f "$DOKKU_ROOT/$app/htpasswd"
+    if fn-http-auth-enabled "$app"; then
+      fn-http-auth-template-config "$app"
+      reload_nginx=true
+    fi
+  done
+
+  if [[ "$reload_nginx" == "true" ]]; then
+    validate_nginx "$app" && restart_nginx "$app" >/dev/null
+  fi
+
+  # handle sudoers
+  local HTTP_AUTH_SUDOERS_FILE="/etc/sudoers.d/dokku-http-auth"
+  echo "%dokku ALL=(ALL) NOPASSWD:$PLUGIN_AVAILABLE_PATH/http-auth/bin/setup-htpasswd *, $PLUGIN_AVAILABLE_PATH/http-auth/bin/teardown-htpasswd *" >"$HTTP_AUTH_SUDOERS_FILE"
+  chmod "0440" "$HTTP_AUTH_SUDOERS_FILE"
 }
 
 trigger-http-auth-install "$@"

--- a/internal-functions
+++ b/internal-functions
@@ -17,43 +17,68 @@ fn-http-auth-enabled() {
 }
 
 fn-http-auth-add-user() {
+  declare desc="add http auth user to app"
   declare APP="$1" AUTH_USERNAME="$2" AUTH_PASSWORD="$3"
   local APP_ROOT="$DOKKU_ROOT/$APP"
 
-  touch "$APP_ROOT/htpasswd"
-  sed -i "/^${AUTH_USERNAME}:/d" "$APP_ROOT/htpasswd"
+  fn-http-auth-init "$APP"
+  sed -i "/^${AUTH_USERNAME}:/d" "$DOKKU_LIB_ROOT/data/http-auth/$APP/htpasswd"
   HASHED_PASSWORD=$(mkpasswd -m sha-512 "$AUTH_PASSWORD")
-  echo "$AUTH_USERNAME:$HASHED_PASSWORD" >>"$APP_ROOT/htpasswd"
+  echo "$AUTH_USERNAME:$HASHED_PASSWORD" >>"$DOKKU_LIB_ROOT/data/http-auth/$APP/htpasswd"
+  fn-http-auth-setup-htpasswd "$APP"
+}
+
+fn-http-auth-init() {
+  declare desc="initialize http auth for app"
+  declare APP="$1"
+  local APP_ROOT="$DOKKU_ROOT/$APP"
+
+  mkdir -p "$DOKKU_LIB_ROOT/data/http-auth/$APP"
+  chown "$DOKKU_SYSTEM_USER:$DOKKU_SYSTEM_GROUP" "$DOKKU_LIB_ROOT/data/http-auth/$APP"
+  touch "$DOKKU_LIB_ROOT/data/http-auth/$APP/htpasswd"
+  chown "$DOKKU_SYSTEM_USER:$DOKKU_SYSTEM_GROUP" "$DOKKU_LIB_ROOT/data/http-auth/$APP/htpasswd"
+}
+
+fn-http-auth-setup-htpasswd() {
+  declare desc="copy htpasswd to nginx"
+  declare APP="$1"
+
+  sudo "$PLUGIN_AVAILABLE_PATH/http-auth/bin/setup-htpasswd" "$APP"
 }
 
 fn-http-auth-list-users() {
+  declare desc="list http auth users for app"
   declare APP="$1"
   local APP_ROOT="$DOKKU_ROOT/$APP"
 
-  touch "$APP_ROOT/htpasswd"
+  fn-http-auth-init "$APP"
   while IFS="" read -r line || [[ -n "$line" ]]; do
     printf '%s\n' "$line" | cut -d':' -f1
-  done <"$APP_ROOT/htpasswd"
+  done <"$DOKKU_LIB_ROOT/data/http-auth/$APP/htpasswd"
+  fn-http-auth-setup-htpasswd "$APP"
 }
 
 fn-http-auth-remove-user() {
+  declare desc="remove http auth user from app"
   declare APP="$1" AUTH_USERNAME="$2"
   local APP_ROOT="$DOKKU_ROOT/$APP"
 
-  touch "$APP_ROOT/htpasswd"
-  sed -i "/^${AUTH_USERNAME}:/d" "$APP_ROOT/htpasswd"
+  fn-http-auth-init "$APP"
+  sed -i "/^${AUTH_USERNAME}:/d" "$DOKKU_LIB_ROOT/data/http-auth/$APP/htpasswd"
+  fn-http-auth-setup-htpasswd "$APP"
 }
 
 fn-http-auth-template-config() {
+  declare desc="template http auth config for app"
   declare APP="$1"
   local APP_ROOT="$DOKKU_ROOT/$APP"
   local DOKKU_TEMPLATE="$PLUGIN_AVAILABLE_PATH/http-auth/templates/http-auth.conf"
-  local HAS_ALLOWED_USERS="$(test -s $APP_ROOT/htpasswd && echo "true")"
-  local ALLOWED_IPS
+  local ALLOWED_IPS HAS_ALLOWED_USERS
 
+  HAS_ALLOWED_USERS="$(test -s "$DOKKU_LIB_ROOT/data/http-auth/$APP" && echo "true")"
+  fn-http-auth-init "$APP"
   ALLOWED_IPS="$(fn-plugin-property-list-get "http-auth" "$APP" "allowed-ips" | xargs)"
   mkdir -p "$APP_ROOT/nginx.conf.d"
-
   sigil -f "$DOKKU_TEMPLATE" APP_ROOT="$APP_ROOT" ALLOWED_IPS="$ALLOWED_IPS" HAS_ALLOWED_USERS="$HAS_ALLOWED_USERS" | cat -s >"$APP_ROOT/nginx.conf.d/http-auth.conf"
-  touch "$APP_ROOT/htpasswd"
+  fn-http-auth-setup-htpasswd "$APP"
 }

--- a/post-delete
+++ b/post-delete
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/property-functions"
+source "$PLUGIN_AVAILABLE_PATH/http-auth/internal-functions"
 set -eo pipefail
 [[ $DOKKU_TRACE ]] && set -x
 
@@ -9,6 +10,9 @@ trigger-http-auth-post-delete() {
   declare APP="$1"
 
   fn-plugin-property-destroy "http-auth" "$APP"
+  sudo "$PLUGIN_AVAILABLE_PATH/http-auth/bin/teardown-htpasswd" "$APP"
+  rm -f "$DOKKU_LIB_ROOT/data/http-auth/$APP"
+  rm -f "$DOKKU_ROOT/$APP/nginx.conf.d/http-auth.conf"
 }
 
 trigger-http-auth-post-delete "$@"

--- a/templates/http-auth.conf
+++ b/templates/http-auth.conf
@@ -8,5 +8,5 @@ deny all;
 
 {{ if $HAS_ALLOWED_USERS }}
 auth_basic           "Restricted";
-auth_basic_user_file {{ $.APP_ROOT }}/htpasswd;
+auth_basic_user_file /etc/nginx/htpasswd/{{ $.APP }};
 {{ end }}

--- a/tests/http_auth_on.bats
+++ b/tests/http_auth_on.bats
@@ -32,7 +32,7 @@ teardown() {
 @test "(http-auth:enable) success" {
   run dokku http-auth:enable my_app user password
   assert_exists "$DOKKU_ROOT/my_app/nginx.conf.d/http-auth.conf"
-  htpasswd=$(< "$DOKKU_ROOT/my_app/htpasswd")
+  htpasswd=$(< "$DOKKU_LIB_ROOT/data/http-auth/my_app/htpasswd")
   assert_equal "$htpasswd" 'user:$6$aXBp2sHg8$EV/2iLc1/26QhyVGjagPvcnaqKpTh1F997mRui43F1ioyH5Nvvn7JA83sJAVJypjHjVvGMBUVwgovXm0BC4Wp0'
   assert_success
 }


### PR DESCRIPTION
Nginx worker processes do not have access to the dokku user's home directory, so they need to be written to a path under /etc/nginx. The nginx conf.d files _will_ be loaded as they are read by the root process (except for SELinux), so while the config gets loaded, the actual htpasswd files will not.

For management purposes, we move the actual files to a new data directory, and then copy it out from there to the /etc/nginx/htpasswd directory for usage by nginx.

Closes #24