### PR TITLE
fix: regenerate http-auth nginx config on deploy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ COMPOSE_COMPOSE_MODE := $(COMPOSE) --profile compose-mode
 COMPOSE_EXEC_DOKKU := $(COMPOSE) exec -T dokku
 
 PLUGIN_BASH_FILES := command-functions commands help-functions install internal-functions \
-	post-app-clone-setup post-app-rename-setup post-delete report \
+	nginx-pre-reload post-app-clone-setup post-app-rename-setup post-delete report \
 	$(wildcard subcommands/*) \
 	tests/setup.sh tests/setup-native.sh tests/test_helper.bash
 

--- a/README.md
+++ b/README.md
@@ -162,6 +162,10 @@ You can pass flags which will output only the value of the specific information 
 dokku http-auth:report node-js-app --http-auth-enabled
 ```
 
+### How state is persisted
+
+Whether HTTP auth is enabled for an app is tracked as an app property, and the generated nginx include (`nginx.conf.d/http-auth.conf`) is regenerated from that state on every deploy. This keeps the include in sync with the configured users and allowed IPs, and restores it automatically if it was ever left empty or out of date.
+
 ## License
 
 This plugin is released under the MIT license. See the file [LICENSE](LICENSE).

--- a/command-functions
+++ b/command-functions
@@ -111,6 +111,7 @@ cmd-http-auth-enable() {
     dokku_log_warn "Skipping user initialization"
   fi
 
+  fn-plugin-property-write "http-auth" "$APP" "enabled" "true"
   fn-http-auth-template-config "$APP"
   validate_nginx "$APP" && restart_nginx "$APP" >/dev/null
   dokku_log_verbose "Done"
@@ -134,6 +135,7 @@ cmd-http-auth-disable() {
   fi
 
   dokku_log_info1 "Disabling HTTP auth for $APP..."
+  fn-plugin-property-write "http-auth" "$APP" "enabled" "false"
   rm -f "$APP_ROOT/nginx.conf.d/http-auth.conf"
   validate_nginx "$APP" && restart_nginx "$APP" >/dev/null
   dokku_log_verbose "Done"
@@ -186,6 +188,7 @@ cmd-http-auth-add-allowed-ip() {
   fi
 
   fn-plugin-property-list-add "http-auth" "$APP" "allowed-ips" "$ADDRESS"
+  fn-plugin-property-write "http-auth" "$APP" "enabled" "true"
   fn-http-auth-template-config "$APP"
   validate_nginx "$APP" && restart_nginx "$APP" >/dev/null
 }

--- a/install
+++ b/install
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/property-functions"
+source "$PLUGIN_AVAILABLE_PATH/http-auth/internal-functions"
 set -eo pipefail
 [[ $DOKKU_TRACE ]] && set -x
 
@@ -8,6 +9,7 @@ trigger-http-auth-install() {
   declare trigger="install"
 
   fn-plugin-property-setup "http-auth"
+  fn-http-auth-migrate-enabled
   if [[ -z "$(which mkpasswd 2>/dev/null)" ]]; then
     apt-get update && apt-get install -y whois
   fi

--- a/internal-functions
+++ b/internal-functions
@@ -6,14 +6,8 @@ set -eo pipefail
 fn-http-auth-enabled() {
   declare desc="check if an app has http-auth enabled"
   declare APP="$1"
-  local APP_ROOT="$DOKKU_ROOT/$APP"
-  local enabled=false
 
-  if [[ -f "$APP_ROOT/nginx.conf.d/http-auth.conf" ]]; then
-    enabled=true
-  fi
-
-  echo "$enabled"
+  fn-plugin-property-get-default "http-auth" "$APP" "enabled" "false"
 }
 
 fn-http-auth-add-user() {
@@ -56,4 +50,17 @@ fn-http-auth-template-config() {
 
   sigil -f "$DOKKU_TEMPLATE" APP_ROOT="$APP_ROOT" ALLOWED_IPS="$ALLOWED_IPS" HAS_ALLOWED_USERS="$HAS_ALLOWED_USERS" | cat -s >"$APP_ROOT/nginx.conf.d/http-auth.conf"
   touch "$APP_ROOT/htpasswd"
+}
+
+fn-http-auth-migrate-enabled() {
+  declare desc="records the enabled property for apps enabled before the property existed"
+  local conf app
+
+  for conf in "$DOKKU_ROOT"/*/nginx.conf.d/http-auth.conf; do
+    [[ -f "$conf" ]] || continue
+    app="$(basename "$(dirname "$(dirname "$conf")")")"
+    if [[ -z "$(fn-plugin-property-get-default "http-auth" "$app" "enabled" "")" ]]; then
+      fn-plugin-property-write "http-auth" "$app" "enabled" "true"
+    fi
+  done
 }

--- a/nginx-pre-reload
+++ b/nginx-pre-reload
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/property-functions"
+source "$PLUGIN_AVAILABLE_PATH/http-auth/internal-functions"
+set -eo pipefail
+[[ $DOKKU_TRACE ]] && set -x
+
+trigger-http-auth-nginx-pre-reload() {
+  declare desc="regenerates the http-auth nginx include whenever nginx config is rebuilt"
+  declare trigger="nginx-pre-reload"
+  declare APP="$1"
+  local APP_ROOT="$DOKKU_ROOT/$APP"
+
+  if [[ "$(fn-http-auth-enabled "$APP")" == "true" ]]; then
+    fn-http-auth-template-config "$APP"
+  else
+    rm -f "$APP_ROOT/nginx.conf.d/http-auth.conf"
+  fi
+}
+
+trigger-http-auth-nginx-pre-reload "$@"

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,6 +1,6 @@
 # Test suite
 
-The bats suite exercises the plugin end-to-end inside a docker-compose stack: a derived dokku image with the plugin source bind-mounted at `/plugin-src`. Tests run inside the dokku container so they call `dokku ...` directly. Apps are created with `apps:create` but never deployed - every assertion is made against the files the plugin manages (`nginx.conf.d/http-auth.conf`, `htpasswd`, and the plugin property store).
+The bats suite exercises the plugin end-to-end inside a docker-compose stack: a derived dokku image with the plugin source bind-mounted at `/plugin-src`. Tests run inside the dokku container so they call `dokku ...` directly. Apps are created with `apps:create` but never deployed - every assertion is made against the files the plugin manages (`nginx.conf.d/http-auth.conf`, `htpasswd`, and the plugin property store). Deploy-time behavior that the plugin hooks into - the `install` and `nginx-pre-reload` triggers - is exercised by invoking the plugin's trigger scripts directly (with the dokku plugin environment the CLI would normally export), so no deploy is required.
 
 ## Running the suite locally
 

--- a/tests/http_auth_disable.bats
+++ b/tests/http_auth_disable.bats
@@ -34,6 +34,12 @@ teardown() {
   assert_disabled "$APP"
 }
 
+@test "(http-auth:disable) records the disabled property" {
+  dokku http-auth:enable "$APP"
+  dokku http-auth:disable "$APP"
+  [ "$(http_auth_property "$APP" enabled)" = "false" ]
+}
+
 @test "(http-auth:disable) keeps the htpasswd file so users survive re-enable" {
   dokku http-auth:enable "$APP" u1 pass1
   dokku http-auth:disable "$APP"

--- a/tests/http_auth_enable.bats
+++ b/tests/http_auth_enable.bats
@@ -57,3 +57,8 @@ teardown() {
   [[ "$output" == *"Deprecated: Please use http-auth:enable"* ]]
   assert_enabled "$APP"
 }
+
+@test "(http-auth:enable) records the enabled property" {
+  dokku http-auth:enable "$APP"
+  [ "$(http_auth_property "$APP" enabled)" = "true" ]
+}

--- a/tests/http_auth_install.bats
+++ b/tests/http_auth_install.bats
@@ -1,0 +1,31 @@
+#!/usr/bin/env bats
+
+load 'test_helper'
+
+setup() {
+  APP="$(new_app_name)"
+  create_app "$APP"
+}
+
+teardown() {
+  cleanup_app "$APP"
+}
+
+@test "(install) migrates a legacy enabled app onto the enabled property" {
+  # Simulate an app enabled before the enabled property existed: a rendered
+  # include survives but no enabled property is recorded.
+  dokku http-auth:enable "$APP" u1 pass1
+  $SUDO rm -f "$(property_dir "$APP")/enabled"
+  assert_disabled "$APP"
+  $SUDO test -f "$(http_auth_conf_path "$APP")"
+  fire_install
+  [ "$(http_auth_property "$APP" enabled)" = "true" ]
+  assert_enabled "$APP"
+}
+
+@test "(install) leaves an app without an include untouched" {
+  # An app that never used http-auth must not gain an enabled property.
+  fire_install
+  [ -z "$(http_auth_property "$APP" enabled)" ]
+  assert_disabled "$APP"
+}

--- a/tests/http_auth_nginx_pre_reload.bats
+++ b/tests/http_auth_nginx_pre_reload.bats
@@ -1,0 +1,51 @@
+#!/usr/bin/env bats
+
+load 'test_helper'
+
+setup() {
+  APP="$(new_app_name)"
+  create_app "$APP"
+}
+
+teardown() {
+  cleanup_app "$APP"
+}
+
+@test "(nginx-pre-reload) re-renders an emptied include for an enabled app" {
+  dokku http-auth:enable "$APP" u1 pass1
+  $SUDO truncate -s 0 "$(http_auth_conf_path "$APP")"
+  [ -z "$(http_auth_conf "$APP")" ]
+  fire_nginx_pre_reload "$APP"
+  run http_auth_conf "$APP"
+  [[ "$output" == *"auth_basic"* ]]
+  [[ "$output" == *"auth_basic_user_file /home/dokku/$APP/htpasswd;"* ]]
+}
+
+@test "(nginx-pre-reload) removes the include for a disabled app" {
+  dokku http-auth:enable "$APP"
+  dokku http-auth:disable "$APP"
+  $SUDO mkdir -p "$(dirname "$(http_auth_conf_path "$APP")")"
+  echo 'auth_basic "Restricted";' | $SUDO tee "$(http_auth_conf_path "$APP")" >/dev/null
+  $SUDO test -f "$(http_auth_conf_path "$APP")"
+  fire_nginx_pre_reload "$APP"
+  $SUDO test ! -f "$(http_auth_conf_path "$APP")"
+}
+
+@test "(nginx-pre-reload) heals an install broken by the pre-fix empty-config bug" {
+  # A healthy enable: user in htpasswd, include with auth_basic, enabled property set.
+  dokku http-auth:enable "$APP" u1 pass1
+  # Reconstruct the exact state shipped by the buggy 0.10.0: the user survives in
+  # htpasswd, the rendered include is empty, and the enabled property predates
+  # this fix so it does not exist yet.
+  $SUDO truncate -s 0 "$(http_auth_conf_path "$APP")"
+  $SUDO rm -f "$(property_dir "$APP")/enabled"
+  assert_disabled "$APP"
+  # A plugin re-install migrates the enabled flag from the surviving include...
+  fire_install
+  [ "$(http_auth_property "$APP" enabled)" = "true" ]
+  # ...and the next nginx rebuild re-renders the include from state.
+  fire_nginx_pre_reload "$APP"
+  run http_auth_conf "$APP"
+  [[ "$output" == *"auth_basic"* ]]
+  [[ "$output" == *"auth_basic_user_file /home/dokku/$APP/htpasswd;"* ]]
+}

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -34,6 +34,38 @@ property_dir() {
   echo "/var/lib/dokku/config/http-auth/$1"
 }
 
+http_auth_property() {
+  $SUDO cat "$(property_dir "$1")/$2" 2>/dev/null || true
+}
+
+# The bats suite never deploys, so plugin triggers are invoked directly. dokku's
+# CLI normally exports the plugin environment; the bats shell does not, so set it
+# here. Paths are the standard install layout, identical in compose and native
+# modes. The plugin's own trigger scripts are run (rather than `plugn trigger`,
+# which fans out to every plugin) to keep each assertion scoped to http-auth.
+dokku_plugin_env() {
+  $SUDO env \
+    DOKKU_ROOT=/home/dokku \
+    DOKKU_LIB_ROOT=/var/lib/dokku \
+    PLUGIN_PATH=/var/lib/dokku/plugins \
+    PLUGIN_AVAILABLE_PATH=/var/lib/dokku/plugins/available \
+    PLUGIN_ENABLED_PATH=/var/lib/dokku/plugins/enabled \
+    PLUGIN_CORE_PATH=/var/lib/dokku/core-plugins \
+    PLUGIN_CORE_AVAILABLE_PATH=/var/lib/dokku/core-plugins/available \
+    "$@"
+}
+
+# Re-render the app's nginx include the way an nginx rebuild would.
+fire_nginx_pre_reload() {
+  dokku_plugin_env /var/lib/dokku/plugins/available/http-auth/nginx-pre-reload "$1" "" "" >/dev/null
+}
+
+# Re-run the plugin's install trigger the way a `dokku plugin:install` upgrade
+# does; used to exercise the http-auth enabled-state migration.
+fire_install() {
+  dokku_plugin_env /var/lib/dokku/plugins/available/http-auth/install >/dev/null
+}
+
 http_auth_conf() {
   $SUDO cat "$(http_auth_conf_path "$1")"
 }


### PR DESCRIPTION
Whether HTTP auth is enabled for an app is now tracked as an authoritative app property instead of being inferred from the presence of the generated nginx include, and that include is regenerated from the stored state on every deploy through an `nginx-pre-reload` trigger. This keeps the include in sync with the configured users and allowed IPs and restores it when it was left empty, so an app enabled before its first deploy or under an older release ends up protected without a manual disable and re-enable. Apps enabled before the property existed are migrated onto it by the plugin install trigger. Fixes #24.
