### PR TITLE
fix: store htpasswd where the nginx worker can read it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ COMPOSE_EXEC_DOKKU := $(COMPOSE) exec -T dokku
 
 PLUGIN_BASH_FILES := command-functions commands help-functions install internal-functions \
 	nginx-pre-reload post-app-clone-setup post-app-rename-setup post-delete report \
+	$(wildcard bin/*) \
 	$(wildcard subcommands/*) \
 	tests/setup.sh tests/setup-native.sh tests/test_helper.bash
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ dokku http-auth:show-config node-js-app username
 
 ```
 auth_basic           "Restricted";
-auth_basic_user_file /home/dokku/node-js-app/htpasswd;
+auth_basic_user_file /etc/nginx/http-auth/node-js-app/htpasswd;
 ```
 
 ### Displaying http auth reports for an app
@@ -165,6 +165,12 @@ dokku http-auth:report node-js-app --http-auth-enabled
 ### How state is persisted
 
 Whether HTTP auth is enabled for an app is tracked as an app property, and the generated nginx include (`nginx.conf.d/http-auth.conf`) is regenerated from that state on every deploy. This keeps the include in sync with the configured users and allowed IPs, and restores it automatically if it was ever left empty or out of date.
+
+### Where the htpasswd file lives
+
+The htpasswd file is stored at `/etc/nginx/http-auth/<app>/htpasswd`. It used to live in the app home directory (`/home/dokku/<app>/htpasswd`), but on Ubuntu 21.04 and newer `/home/dokku` is created mode `750`, which the nginx worker (running as `www-data`) cannot traverse - so reading the `auth_basic_user_file` at request time failed with a `permission denied` error and a 500. `/etc/nginx` is traversable by the worker, so the file is readable there.
+
+The directory is owned by `root` and dokku manages it through a small helper granted access via `/etc/sudoers.d/dokku-http-auth`, which is installed when the plugin is installed. Existing installs are migrated automatically on plugin upgrade. Because the file lives under the world-traversable `/etc/nginx`, its salted SHA-512 password hashes are readable by local users on the host; the file previously relied on `/home/dokku`'s restrictive permissions for that.
 
 ## License
 

--- a/bin/set-htpasswd
+++ b/bin/set-htpasswd
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Privileged filesystem helper for the http-auth plugin.
+#
+# The htpasswd files live under a root-owned /etc/nginx tree so the nginx
+# worker (www-data) can read them, but dokku CLI commands run as the dokku
+# user. This helper is the only thing granted (via /etc/sudoers.d/dokku-http-auth)
+# to mutate that tree as root. It never accepts a path: every operation takes an
+# app name, validates it, and builds the path itself, confining all writes to
+# BASE/<app>. Callers pipe htpasswd content (hashes only) on stdin.
+set -eo pipefail
+[[ $DOKKU_TRACE ]] && set -x
+
+BASE="/etc/nginx/http-auth"
+
+fn-http-auth-helper-fail() {
+  declare desc="print an error and exit non-zero"
+  echo " !     $1" 1>&2
+  exit 1
+}
+
+fn-http-auth-helper-validate-app() {
+  declare desc="reject any app name that could escape BASE"
+  declare APP="$1"
+
+  [[ -n "$APP" ]] || fn-http-auth-helper-fail "Missing app name"
+  # Mirrors dokku's app-name rules (IsValidAppNameOld): begins with a lowercase
+  # alphanumeric, then lowercase alphanumerics, dots, underscores, hyphens. This
+  # forbids "/", "." and ".." components, so the app name cannot escape BASE.
+  if [[ ! "$APP" =~ ^[a-z0-9][a-z0-9._-]*$ ]]; then
+    fn-http-auth-helper-fail "Invalid app name: $APP"
+  fi
+}
+
+fn-http-auth-helper-mkdir() {
+  declare desc="create BASE/<app> readable+traversable by nginx"
+  declare DIR="$1"
+
+  mkdir -p "$DIR"
+  chmod 755 "$BASE" "$DIR"
+}
+
+main() {
+  declare CMD="$1"
+
+  case "$CMD" in
+    write)
+      declare APP="$2"
+      fn-http-auth-helper-validate-app "$APP"
+      local dir="$BASE/$APP"
+      fn-http-auth-helper-mkdir "$dir"
+      local tmp="$dir/.htpasswd.$$"
+      cat >"$tmp"
+      chmod 644 "$tmp"
+      mv -f "$tmp" "$dir/htpasswd"
+      ;;
+
+    ensure)
+      declare APP="$2"
+      fn-http-auth-helper-validate-app "$APP"
+      local dir="$BASE/$APP"
+      fn-http-auth-helper-mkdir "$dir"
+      [[ -f "$dir/htpasswd" ]] || : >"$dir/htpasswd"
+      chmod 644 "$dir/htpasswd"
+      ;;
+
+    remove)
+      declare APP="$2"
+      fn-http-auth-helper-validate-app "$APP"
+      rm -rf "${BASE:?}/$APP"
+      ;;
+
+    clone)
+      declare OLD_APP="$2" NEW_APP="$3"
+      fn-http-auth-helper-validate-app "$OLD_APP"
+      fn-http-auth-helper-validate-app "$NEW_APP"
+      if [[ -d "$BASE/$OLD_APP" ]]; then
+        rm -rf "${BASE:?}/$NEW_APP"
+        cp -a "$BASE/$OLD_APP" "$BASE/$NEW_APP"
+      fi
+      ;;
+
+    rename)
+      declare OLD_APP="$2" NEW_APP="$3"
+      fn-http-auth-helper-validate-app "$OLD_APP"
+      fn-http-auth-helper-validate-app "$NEW_APP"
+      if [[ -d "$BASE/$OLD_APP" ]]; then
+        rm -rf "${BASE:?}/$NEW_APP"
+        mv "$BASE/$OLD_APP" "$BASE/$NEW_APP"
+      fi
+      ;;
+
+    *)
+      fn-http-auth-helper-fail "Unknown command: $CMD"
+      ;;
+  esac
+}
+
+main "$@"

--- a/install
+++ b/install
@@ -1,15 +1,33 @@
 #!/usr/bin/env bash
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/property-functions"
 source "$PLUGIN_AVAILABLE_PATH/http-auth/internal-functions"
+source "$PLUGIN_AVAILABLE_PATH/nginx-vhosts/functions"
 set -eo pipefail
 [[ $DOKKU_TRACE ]] && set -x
+
+fn-http-auth-install-sudoers() {
+  declare desc="grants the dokku user access to the privileged htpasswd helper"
+  local sudoers_file="/etc/sudoers.d/dokku-http-auth"
+  local helper
+  helper="$(fn-http-auth-htpasswd-helper)"
+
+  echo "%dokku ALL=(ALL) NOPASSWD:$helper *" >"$sudoers_file"
+  chmod 0440 "$sudoers_file"
+  if command -v visudo >/dev/null 2>&1 && ! visudo -cf "$sudoers_file" >/dev/null 2>&1; then
+    rm -f "$sudoers_file"
+    dokku_log_warn "Generated an invalid sudoers file for http-auth; removed it"
+  fi
+}
 
 trigger-http-auth-install() {
   declare desc="installs the http-auth plugin"
   declare trigger="install"
 
   fn-plugin-property-setup "http-auth"
+  fn-http-auth-install-sudoers
   fn-http-auth-migrate-enabled
+  fn-http-auth-migrate-htpasswd-all
   if [[ -z "$(which mkpasswd 2>/dev/null)" ]]; then
     apt-get update && apt-get install -y whois
   fi

--- a/internal-functions
+++ b/internal-functions
@@ -10,46 +10,111 @@ fn-http-auth-enabled() {
   fn-plugin-property-get-default "http-auth" "$APP" "enabled" "false"
 }
 
+fn-http-auth-htpasswd-helper() {
+  declare desc="path to the privileged htpasswd filesystem helper"
+
+  echo "$PLUGIN_AVAILABLE_PATH/http-auth/bin/set-htpasswd"
+}
+
+fn-http-auth-htpasswd-dir() {
+  declare desc="nginx-readable directory holding an app's htpasswd"
+  declare APP="$1"
+
+  echo "/etc/nginx/http-auth/$APP"
+}
+
+fn-http-auth-htpasswd-path() {
+  declare desc="path to an app's htpasswd file"
+  declare APP="$1"
+
+  echo "$(fn-http-auth-htpasswd-dir "$APP")/htpasswd"
+}
+
+fn-http-auth-legacy-htpasswd-path() {
+  declare desc="path to the htpasswd stored in the app home directory before it was moved under /etc/nginx"
+  declare APP="$1"
+
+  echo "$DOKKU_ROOT/$APP/htpasswd"
+}
+
+fn-http-auth-current-htpasswd() {
+  declare desc="emit an app's current htpasswd, preferring the new location and falling back to the legacy one"
+  declare APP="$1"
+  local new legacy
+  new="$(fn-http-auth-htpasswd-path "$APP")"
+  legacy="$(fn-http-auth-legacy-htpasswd-path "$APP")"
+
+  if [[ -f "$new" ]]; then
+    cat "$new"
+  elif [[ -f "$legacy" ]]; then
+    cat "$legacy"
+  fi
+}
+
+fn-http-auth-has-htpasswd() {
+  declare desc="check whether an app has an htpasswd in either the new or legacy location"
+  declare APP="$1"
+
+  [[ -d "$(fn-http-auth-htpasswd-dir "$APP")" ]] || [[ -f "$(fn-http-auth-legacy-htpasswd-path "$APP")" ]]
+}
+
+fn-http-auth-set-htpasswd() {
+  declare desc="write htpasswd contents from stdin to the nginx-readable location via the privileged helper"
+  declare APP="$1"
+
+  sudo "$(fn-http-auth-htpasswd-helper)" write "$APP"
+}
+
+fn-http-auth-ensure-htpasswd() {
+  declare desc="ensure the htpasswd exists in the nginx-readable location, migrating legacy content forward"
+  declare APP="$1"
+
+  if [[ -f "$(fn-http-auth-htpasswd-path "$APP")" ]]; then
+    sudo "$(fn-http-auth-htpasswd-helper)" ensure "$APP"
+  else
+    fn-http-auth-current-htpasswd "$APP" | fn-http-auth-set-htpasswd "$APP"
+  fi
+}
+
 fn-http-auth-add-user() {
   declare APP="$1" AUTH_USERNAME="$2" AUTH_PASSWORD="$3"
-  local APP_ROOT="$DOKKU_ROOT/$APP"
+  local HASHED_PASSWORD
+  HASHED_PASSWORD="$(mkpasswd -m sha-512 "$AUTH_PASSWORD")"
 
-  touch "$APP_ROOT/htpasswd"
-  sed -i "/^${AUTH_USERNAME}:/d" "$APP_ROOT/htpasswd"
-  HASHED_PASSWORD=$(mkpasswd -m sha-512 "$AUTH_PASSWORD")
-  echo "$AUTH_USERNAME:$HASHED_PASSWORD" >>"$APP_ROOT/htpasswd"
+  {
+    fn-http-auth-current-htpasswd "$APP" | sed "/^${AUTH_USERNAME}:/d"
+    printf '%s:%s\n' "$AUTH_USERNAME" "$HASHED_PASSWORD"
+  } | fn-http-auth-set-htpasswd "$APP"
 }
 
 fn-http-auth-list-users() {
   declare APP="$1"
-  local APP_ROOT="$DOKKU_ROOT/$APP"
 
-  touch "$APP_ROOT/htpasswd"
-  while IFS="" read -r line || [[ -n "$line" ]]; do
+  fn-http-auth-current-htpasswd "$APP" | while IFS="" read -r line || [[ -n "$line" ]]; do
     printf '%s\n' "$line" | cut -d':' -f1
-  done <"$APP_ROOT/htpasswd"
+  done
 }
 
 fn-http-auth-remove-user() {
   declare APP="$1" AUTH_USERNAME="$2"
-  local APP_ROOT="$DOKKU_ROOT/$APP"
 
-  touch "$APP_ROOT/htpasswd"
-  sed -i "/^${AUTH_USERNAME}:/d" "$APP_ROOT/htpasswd"
+  fn-http-auth-current-htpasswd "$APP" | sed "/^${AUTH_USERNAME}:/d" | fn-http-auth-set-htpasswd "$APP"
 }
 
 fn-http-auth-template-config() {
   declare APP="$1"
   local APP_ROOT="$DOKKU_ROOT/$APP"
   local DOKKU_TEMPLATE="$PLUGIN_AVAILABLE_PATH/http-auth/templates/http-auth.conf"
-  local HAS_ALLOWED_USERS="$(test -s $APP_ROOT/htpasswd && echo "true")"
-  local ALLOWED_IPS
+  local HTPASSWD_PATH ALLOWED_IPS
 
+  fn-http-auth-ensure-htpasswd "$APP"
+  HTPASSWD_PATH="$(fn-http-auth-htpasswd-path "$APP")"
+  # `local` keeps the failing `test -s` (empty htpasswd) from tripping `set -e`
+  local HAS_ALLOWED_USERS="$(test -s "$HTPASSWD_PATH" && echo "true")"
   ALLOWED_IPS="$(fn-plugin-property-list-get "http-auth" "$APP" "allowed-ips" | xargs)"
   mkdir -p "$APP_ROOT/nginx.conf.d"
 
-  sigil -f "$DOKKU_TEMPLATE" APP_ROOT="$APP_ROOT" ALLOWED_IPS="$ALLOWED_IPS" HAS_ALLOWED_USERS="$HAS_ALLOWED_USERS" | cat -s >"$APP_ROOT/nginx.conf.d/http-auth.conf"
-  touch "$APP_ROOT/htpasswd"
+  sigil -f "$DOKKU_TEMPLATE" HTPASSWD_PATH="$HTPASSWD_PATH" ALLOWED_IPS="$ALLOWED_IPS" HAS_ALLOWED_USERS="$HAS_ALLOWED_USERS" | cat -s >"$APP_ROOT/nginx.conf.d/http-auth.conf"
 }
 
 fn-http-auth-migrate-enabled() {
@@ -63,4 +128,27 @@ fn-http-auth-migrate-enabled() {
       fn-plugin-property-write "http-auth" "$app" "enabled" "true"
     fi
   done
+}
+
+fn-http-auth-migrate-htpasswd-all() {
+  declare desc="relocates enabled apps' htpasswd files out of the app home directory and into the nginx-readable location"
+  local legacy app migrated=false
+
+  for legacy in "$DOKKU_ROOT"/*/htpasswd; do
+    [[ -f "$legacy" ]] || continue
+    app="$(basename "$(dirname "$legacy")")"
+    # only migrate enabled apps: disable leaves the htpasswd behind, and
+    # re-rendering the include for a disabled app would resurrect auth
+    [[ "$(fn-http-auth-enabled "$app")" == "true" ]] || continue
+    # idempotent: skip apps already moved so repeat installs do not reload nginx
+    [[ -f "$(fn-http-auth-htpasswd-path "$app")" ]] && continue
+    fn-http-auth-template-config "$app" || continue
+    migrated=true
+  done
+
+  [[ "$migrated" == "true" ]] || return 0
+  # pick up the repointed includes without waiting for a redeploy
+  if fn-nginx-vhosts-nginx-is-running 2>/dev/null; then
+    { nginx -t >/dev/null 2>&1 && fn-nginx-vhosts-nginx-init-cmd reload; } || true
+  fi
 }

--- a/post-app-clone-setup
+++ b/post-app-clone-setup
@@ -1,14 +1,22 @@
 #!/usr/bin/env bash
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/property-functions"
+source "$PLUGIN_AVAILABLE_PATH/http-auth/internal-functions"
 set -eo pipefail
 [[ $DOKKU_TRACE ]] && set -x
 
 trigger-http-auth-post-app-clone-setup() {
-  declare desc="sets up properties for new app"
+  declare desc="clones properties and htpasswd for the new app"
   declare trigger="post-app-clone-setup"
   declare OLD_APP="$1" NEW_APP="$2"
 
   fn-plugin-property-clone "http-auth" "$OLD_APP" "$NEW_APP"
+  if fn-http-auth-has-htpasswd "$OLD_APP"; then
+    fn-http-auth-ensure-htpasswd "$OLD_APP"
+    sudo "$(fn-http-auth-htpasswd-helper)" clone "$OLD_APP" "$NEW_APP"
+  fi
+  if [[ "$(fn-http-auth-enabled "$NEW_APP")" == "true" ]]; then
+    fn-http-auth-template-config "$NEW_APP"
+  fi
 }
 
 trigger-http-auth-post-app-clone-setup "$@"

--- a/post-app-rename-setup
+++ b/post-app-rename-setup
@@ -1,15 +1,23 @@
 #!/usr/bin/env bash
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/property-functions"
+source "$PLUGIN_AVAILABLE_PATH/http-auth/internal-functions"
 set -eo pipefail
 [[ $DOKKU_TRACE ]] && set -x
 
 trigger-http-auth-post-app-rename-setup() {
-  declare desc="updates settings for new app"
+  declare desc="moves properties and htpasswd to the new app name"
   declare trigger="post-app-rename-setup"
   declare OLD_APP="$1" NEW_APP="$2"
 
   fn-plugin-property-clone "http-auth" "$OLD_APP" "$NEW_APP"
   fn-plugin-property-destroy "http-auth" "$OLD_APP"
+  if fn-http-auth-has-htpasswd "$OLD_APP"; then
+    fn-http-auth-ensure-htpasswd "$OLD_APP"
+    sudo "$(fn-http-auth-htpasswd-helper)" rename "$OLD_APP" "$NEW_APP"
+  fi
+  if [[ "$(fn-http-auth-enabled "$NEW_APP")" == "true" ]]; then
+    fn-http-auth-template-config "$NEW_APP"
+  fi
 }
 
 trigger-http-auth-post-app-rename-setup "$@"

--- a/post-delete
+++ b/post-delete
@@ -1,14 +1,18 @@
 #!/usr/bin/env bash
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/property-functions"
+source "$PLUGIN_AVAILABLE_PATH/http-auth/internal-functions"
 set -eo pipefail
 [[ $DOKKU_TRACE ]] && set -x
 
 trigger-http-auth-post-delete() {
-  declare desc="destroys the http-auth properties for a given app"
+  declare desc="destroys the http-auth properties and htpasswd for a given app"
   declare trigger="post-delete"
   declare APP="$1"
 
   fn-plugin-property-destroy "http-auth" "$APP"
+  if fn-http-auth-has-htpasswd "$APP"; then
+    sudo "$(fn-http-auth-htpasswd-helper)" remove "$APP"
+  fi
 }
 
 trigger-http-auth-post-delete "$@"

--- a/templates/http-auth.conf
+++ b/templates/http-auth.conf
@@ -8,5 +8,5 @@ deny all;
 
 {{ if $HAS_ALLOWED_USERS }}
 auth_basic           "Restricted";
-auth_basic_user_file {{ $.APP_ROOT }}/htpasswd;
+auth_basic_user_file {{ $.HTPASSWD_PATH }};
 {{ end }}

--- a/tests/http_auth_enable.bats
+++ b/tests/http_auth_enable.bats
@@ -25,7 +25,13 @@ teardown() {
   htpasswd_contents "$APP" | grep -q '^testuser:\$6\$'
   run http_auth_conf "$APP"
   [[ "$output" == *"auth_basic"* ]]
-  [[ "$output" == *"auth_basic_user_file /home/dokku/$APP/htpasswd;"* ]]
+  [[ "$output" == *"auth_basic_user_file $(htpasswd_path "$APP");"* ]]
+}
+
+@test "(http-auth:enable) stores the htpasswd under /etc/nginx, not the app home directory" {
+  dokku http-auth:enable "$APP" testuser testpass
+  $SUDO test -f "$(htpasswd_path "$APP")"
+  $SUDO test ! -f "$(legacy_htpasswd_path "$APP")"
 }
 
 @test "(http-auth:enable) without credentials warns about skipping user initialization" {

--- a/tests/http_auth_helper.bats
+++ b/tests/http_auth_helper.bats
@@ -1,0 +1,53 @@
+#!/usr/bin/env bats
+# Exercises the privileged bin/set-htpasswd helper directly, including its
+# app-name validation - the security boundary that keeps every write confined
+# to /etc/nginx/http-auth.
+
+load 'test_helper'
+
+setup() {
+  APP="$(new_app_name)"
+}
+
+teardown() {
+  $SUDO "$(set_htpasswd_helper)" remove "$APP" 2>/dev/null || true
+}
+
+@test "(set-htpasswd) write round-trips stdin to the app's htpasswd with mode 644" {
+  echo 'u1:$6$hash' | $SUDO "$(set_htpasswd_helper)" write "$APP"
+  $SUDO test -f "$(htpasswd_path "$APP")"
+  [ "$(htpasswd_contents "$APP")" = 'u1:$6$hash' ]
+  [ "$($SUDO stat -c '%a' "$(htpasswd_path "$APP")")" = "644" ]
+  [ "$($SUDO stat -c '%a' "$(htpasswd_dir "$APP")")" = "755" ]
+}
+
+@test "(set-htpasswd) ensure creates an empty htpasswd without clobbering an existing one" {
+  echo 'u1:$6$hash' | $SUDO "$(set_htpasswd_helper)" write "$APP"
+  $SUDO "$(set_htpasswd_helper)" ensure "$APP"
+  [ "$(htpasswd_contents "$APP")" = 'u1:$6$hash' ]
+}
+
+@test "(set-htpasswd) remove deletes the app's htpasswd directory" {
+  echo 'u1:$6$hash' | $SUDO "$(set_htpasswd_helper)" write "$APP"
+  $SUDO test -d "$(htpasswd_dir "$APP")"
+  $SUDO "$(set_htpasswd_helper)" remove "$APP"
+  $SUDO test ! -d "$(htpasswd_dir "$APP")"
+}
+
+@test "(set-htpasswd) rejects an app name containing a slash" {
+  run bash -c "echo pwned | $(set_htpasswd_helper) write 'foo/bar'"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Invalid app name"* ]]
+}
+
+@test "(set-htpasswd) rejects a path-traversal app name and writes nothing outside the tree" {
+  run bash -c "echo pwned | $(set_htpasswd_helper) write '../../../../../../etc/cron.d/pwn'"
+  [ "$status" -ne 0 ]
+  test ! -f /etc/cron.d/pwn
+}
+
+@test "(set-htpasswd) rejects an empty app name" {
+  run bash -c "echo pwned | $(set_htpasswd_helper) write ''"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Missing app name"* ]]
+}

--- a/tests/http_auth_hooks.bats
+++ b/tests/http_auth_hooks.bats
@@ -15,33 +15,46 @@ teardown() {
   fi
 }
 
-@test "(http-auth) post-delete destroys the plugin properties on apps:destroy" {
-  dokku http-auth:add-allowed-ip "$APP" 10.0.0.1
+@test "(http-auth) post-delete destroys the plugin properties and htpasswd on apps:destroy" {
+  dokku http-auth:enable "$APP" u1 pass1
   $SUDO test -d "$(property_dir "$APP")"
+  $SUDO test -d "$(htpasswd_dir "$APP")"
   dokku --force apps:destroy "$APP"
   $SUDO test ! -d "$(property_dir "$APP")"
+  $SUDO test ! -d "$(htpasswd_dir "$APP")"
 }
 
-@test "(http-auth) post-app-clone-setup clones the plugin properties to the new app" {
+@test "(http-auth) post-app-clone-setup clones properties and htpasswd to the new app" {
   APP2="$(new_app_name)"
+  dokku http-auth:enable "$APP" u1 pass1
   dokku http-auth:add-allowed-ip "$APP" 10.0.0.1
   dokku apps:clone --skip-deploy "$APP" "$APP2"
   run dokku http-auth:report "$APP2" --http-auth-allowed-ips
   [ "$status" -eq 0 ]
   [ "$output" = "10.0.0.1" ]
-  # apps:clone copies the app directory, so the rendered config and the
-  # enabled state travel with the app
   assert_enabled "$APP2"
+  # the htpasswd is copied into the new app's own directory and the include
+  # references that path, not the source app's
+  $SUDO test -f "$(htpasswd_path "$APP2")"
+  htpasswd_contents "$APP2" | grep -q '^u1:\$6\$'
   run http_auth_conf "$APP2"
   [[ "$output" == *"allow 10.0.0.1;"* ]]
+  [[ "$output" == *"auth_basic_user_file $(htpasswd_path "$APP2");"* ]]
 }
 
-@test "(http-auth) post-app-rename-setup moves the plugin properties to the new name" {
+@test "(http-auth) post-app-rename-setup moves properties and htpasswd to the new name" {
   APP2="$(new_app_name)"
+  dokku http-auth:enable "$APP" u1 pass1
   dokku http-auth:add-allowed-ip "$APP" 10.0.0.1
   dokku apps:rename --skip-deploy "$APP" "$APP2"
   run dokku http-auth:report "$APP2" --http-auth-allowed-ips
   [ "$status" -eq 0 ]
   [ "$output" = "10.0.0.1" ]
   $SUDO test ! -d "$(property_dir "$APP")"
+  # the htpasswd dir moves to the new name and the include repoints
+  $SUDO test ! -d "$(htpasswd_dir "$APP")"
+  $SUDO test -f "$(htpasswd_path "$APP2")"
+  htpasswd_contents "$APP2" | grep -q '^u1:\$6\$'
+  run http_auth_conf "$APP2"
+  [[ "$output" == *"auth_basic_user_file $(htpasswd_path "$APP2");"* ]]
 }

--- a/tests/http_auth_install.bats
+++ b/tests/http_auth_install.bats
@@ -29,3 +29,43 @@ teardown() {
   [ -z "$(http_auth_property "$APP" enabled)" ]
   assert_disabled "$APP"
 }
+
+@test "(install) writes the sudoers entry for the htpasswd helper" {
+  fire_install
+  $SUDO test -f /etc/sudoers.d/dokku-http-auth
+}
+
+@test "(install) relocates a legacy enabled app's htpasswd into /etc/nginx" {
+  # Reconstruct the pre-move layout: htpasswd and include live in the app home
+  # directory and the include points at the old path. migrate-enabled records
+  # the enabled state from the surviving include, then the htpasswd migration
+  # copies the file forward and repoints the include.
+  local legacy conf
+  legacy="$(legacy_htpasswd_path "$APP")"
+  conf="$(http_auth_conf_path "$APP")"
+  echo 'u1:$6$seededhash' | $SUDO tee "$legacy" >/dev/null
+  $SUDO mkdir -p "$(dirname "$conf")"
+  { echo 'auth_basic "Restricted";'; echo "auth_basic_user_file $legacy;"; } | $SUDO tee "$conf" >/dev/null
+
+  fire_install
+
+  $SUDO test -f "$(htpasswd_path "$APP")"
+  [ "$(htpasswd_contents "$APP")" = 'u1:$6$seededhash' ]
+  run http_auth_conf "$APP"
+  [[ "$output" == *"auth_basic_user_file $(htpasswd_path "$APP");"* ]]
+}
+
+@test "(install) does not resurrect auth for a disabled app with a lingering htpasswd" {
+  # An app enabled then disabled leaves its htpasswd behind but removes the
+  # include. A plugin upgrade must not re-render an include for it.
+  dokku http-auth:enable "$APP"
+  dokku http-auth:disable "$APP"
+  $SUDO rm -rf "$(htpasswd_dir "$APP")"
+  echo 'u1:$6$seededhash' | $SUDO tee "$(legacy_htpasswd_path "$APP")" >/dev/null
+
+  fire_install
+
+  assert_disabled "$APP"
+  $SUDO test ! -f "$(http_auth_conf_path "$APP")"
+  $SUDO test ! -d "$(htpasswd_dir "$APP")"
+}

--- a/tests/http_auth_nginx_pre_reload.bats
+++ b/tests/http_auth_nginx_pre_reload.bats
@@ -18,7 +18,7 @@ teardown() {
   fire_nginx_pre_reload "$APP"
   run http_auth_conf "$APP"
   [[ "$output" == *"auth_basic"* ]]
-  [[ "$output" == *"auth_basic_user_file /home/dokku/$APP/htpasswd;"* ]]
+  [[ "$output" == *"auth_basic_user_file $(htpasswd_path "$APP");"* ]]
 }
 
 @test "(nginx-pre-reload) removes the include for a disabled app" {
@@ -47,5 +47,5 @@ teardown() {
   fire_nginx_pre_reload "$APP"
   run http_auth_conf "$APP"
   [[ "$output" == *"auth_basic"* ]]
-  [[ "$output" == *"auth_basic_user_file /home/dokku/$APP/htpasswd;"* ]]
+  [[ "$output" == *"auth_basic_user_file $(htpasswd_path "$APP");"* ]]
 }

--- a/tests/http_auth_users.bats
+++ b/tests/http_auth_users.bats
@@ -23,7 +23,7 @@ teardown() {
   dokku http-auth:add-user "$APP" u1 pass1
   run http_auth_conf "$APP"
   [[ "$output" == *"auth_basic"* ]]
-  [[ "$output" == *"auth_basic_user_file /home/dokku/$APP/htpasswd;"* ]]
+  [[ "$output" == *"auth_basic_user_file $(htpasswd_path "$APP");"* ]]
 }
 
 @test "(http-auth:add-user) replaces the password of an existing user" {

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -26,8 +26,22 @@ http_auth_conf_path() {
   echo "/home/dokku/$1/nginx.conf.d/http-auth.conf"
 }
 
+# The htpasswd now lives under a root-owned /etc/nginx tree so the nginx worker
+# can read it; the legacy location was the app home directory.
+htpasswd_dir() {
+  echo "/etc/nginx/http-auth/$1"
+}
+
 htpasswd_path() {
+  echo "$(htpasswd_dir "$1")/htpasswd"
+}
+
+legacy_htpasswd_path() {
   echo "/home/dokku/$1/htpasswd"
+}
+
+set_htpasswd_helper() {
+  echo "/var/lib/dokku/plugins/available/http-auth/bin/set-htpasswd"
 }
 
 property_dir() {


### PR DESCRIPTION
On Ubuntu 21.04 and newer the dokku home directory is created mode `750`, which the nginx worker process cannot traverse, so reading the per-app `auth_basic_user_file` failed at request time with a permission error and returned a 500. The htpasswd is now stored under `/etc/nginx/http-auth/<app>` where the worker can read it, and existing installs are migrated automatically on upgrade.

Closes #15.