### PR TITLE
feat: restrict http auth to specific domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,14 @@ $ dokku plugin:install https://github.com/dokku/dokku-http-auth.git
 $ dokku http-auth:help
     http-auth:add-user <app> <user> <password>  Add basic auth user to app
     http-auth:add-allowed-ip <app> <address>    Add allowed IP to basic auth bypass for an app
+    http-auth:add-domain <app> <domain>         Restrict basic auth to the given domain (empty list = all domains)
     http-auth:disable <app>                     Disable HTTP auth for app
     http-auth:enable <app> <user> <password>    Enable HTTP auth for app
     http-auth:remove-allowed-ip <app> <address> Remove allowed IP from basic auth bypass for an app
+    http-auth:remove-domain <app> <domain>      Stop restricting basic auth to the given domain
     http-auth:remove-user <app> <user>          Remove basic auth user from app
     http-auth:report [<app>] [<flag>]           Displays an http-auth report for one or more apps
+    http-auth:set-domains <app> [<domain>...]   Replace the set of domains basic auth is restricted to
     http-auth:show-config <app>                 Display app http-auth config
 ```
 
@@ -128,6 +131,53 @@ dokku http-auth:remove-allowed-ip node-js-app 127.0.0.1
        Reloading nginx
 ```
 
+### Restricting auth to specific domains
+
+By default HTTP auth applies to every domain attached to an app. When an app serves
+multiple domains you can restrict the password prompt to a subset of them, leaving the
+others public.
+
+Add a domain to the auth list with `http-auth:add-domain`. The domain must already be
+attached to the app (see `dokku domains:report`); an unattached domain is rejected. Adding
+a domain enables HTTP auth for the app if it was not already enabled.
+
+```shell
+dokku http-auth:add-domain node-js-app secure.example.com
+```
+
+```
+-----> Adding secure.example.com to auth domain list
+-----> Configuring node-js-app.dokku.me...(using built-in template)
+-----> Creating https nginx.conf
+       Reloading nginx
+```
+
+While the auth domain list is non-empty, only the listed domains present the password
+prompt; every other domain of the app is served without auth. When the list is empty (the
+default) auth applies to all of the app's domains, exactly as before.
+
+Remove a single domain with `http-auth:remove-domain`:
+
+```shell
+dokku http-auth:remove-domain node-js-app secure.example.com
+```
+
+Replace the entire list in one call with `http-auth:set-domains`. Passing no domains clears
+the list, returning the app to app-wide auth:
+
+```shell
+# restrict auth to exactly these two domains
+dokku http-auth:set-domains node-js-app secure.example.com admin.example.com
+
+# clear the list -> auth applies to all domains again
+dokku http-auth:set-domains node-js-app
+```
+
+> **Note:** allowed IPs (`http-auth:add-allowed-ip`) apply to **all** of an app's domains and
+> cannot be scoped per-domain. If you combine allowed IPs with a domain restriction, a domain
+> that is not in the auth list will still reject clients whose IP is not allowed (HTTP 403)
+> rather than being fully public. The plugin prints a warning when the two features are combined.
+
 ### Viewing http auth config
 
 The nginx `http-auth.conf` file can be viewed via the `http-auth:show-config` command. This command will _not_ output the `htaccess` file.
@@ -138,6 +188,17 @@ dokku http-auth:show-config node-js-app username
 
 ```
 auth_basic           "Restricted";
+auth_basic_user_file /etc/nginx/http-auth/node-js-app/htpasswd;
+```
+
+When auth is restricted to specific domains, the realm is gated on the request host instead:
+
+```
+set $dokku_auth_realm off;
+if ($host = "secure.example.com") {
+  set $dokku_auth_realm "Restricted";
+}
+auth_basic           $dokku_auth_realm;
 auth_basic_user_file /etc/nginx/http-auth/node-js-app/htpasswd;
 ```
 
@@ -153,8 +214,12 @@ You can get a report about the app's http-auth status using the `http-auth:repor
 =====> node-js-app http-auth information
        Http auth enabled:             true
        Http auth allowed ips:         127.0.0.1
+       Http auth domains:             secure.example.com
        Http auth users:               root username
 ```
+
+The `Http auth domains` row (and the `--http-auth-domains` flag) lists the domains auth is
+restricted to; an empty value means auth applies to all of the app's domains.
 
 You can pass flags which will output only the value of the specific information you want. For example:
 
@@ -168,7 +233,7 @@ Whether HTTP auth is enabled for an app is tracked as an app property, and the g
 
 ### Renaming, cloning, and destroying apps
 
-Because the htpasswd file lives outside the app home directory, the plugin keeps it in sync as apps move. Renaming an app moves both the enabled/allowed-ip state and the htpasswd to the new app, cloning an app copies them, and in both cases the nginx include is re-rendered to point at the new app's htpasswd. This means a renamed or cloned app keeps working with the same credentials, with no need to disable and re-enable HTTP auth. Destroying an app removes its properties and htpasswd.
+Because the htpasswd file lives outside the app home directory, the plugin keeps it in sync as apps move. Renaming an app moves the enabled state, allowed-ip and auth-domain lists, and the htpasswd to the new app, cloning an app copies them, and in both cases the nginx include is re-rendered to point at the new app's htpasswd. This means a renamed or cloned app keeps working with the same credentials, with no need to disable and re-enable HTTP auth. Destroying an app removes its properties and htpasswd.
 
 ### Where the htpasswd file lives
 

--- a/command-functions
+++ b/command-functions
@@ -41,6 +41,7 @@ cmd-http-auth-report-single() {
   local flag_map=(
     "--http-auth-enabled: $(fn-http-auth-enabled "$APP")"
     "--http-auth-allowed-ips: $(fn-plugin-property-list-get "http-auth" "$APP" "allowed-ips" | xargs)"
+    "--http-auth-domains: $(fn-plugin-property-list-get "http-auth" "$APP" "auth-domains" | xargs)"
     "--http-auth-users: $(fn-http-auth-list-users "$APP" | xargs)"
   )
 
@@ -60,7 +61,7 @@ cmd-http-auth-report-single() {
         size="${#value}"
         if [[ "$size" -ne 0 ]]; then
           echo "$value" && match=true && value_exists=true
-        elif [[ "$INFO_FLAG" == "--http-auth-allowed-ips" ]]; then
+        elif [[ "$INFO_FLAG" == "--http-auth-allowed-ips" ]] || [[ "$INFO_FLAG" == "--http-auth-domains" ]]; then
           match=true && value_exists=true
         else
           match=true
@@ -189,6 +190,9 @@ cmd-http-auth-add-allowed-ip() {
 
   fn-plugin-property-list-add "http-auth" "$APP" "allowed-ips" "$ADDRESS"
   fn-plugin-property-write "http-auth" "$APP" "enabled" "true"
+  if fn-http-auth-has-auth-domains "$APP"; then
+    fn-http-auth-warn-ip-domain-overlap
+  fi
   fn-http-auth-template-config "$APP"
   validate_nginx "$APP" && restart_nginx "$APP" >/dev/null
 }
@@ -231,6 +235,103 @@ cmd-http-auth-remove-allowed-ip() {
 
   dokku_log_info1 "Removing $ADDRESS from allowed ip list"
   fn-plugin-property-list-remove "http-auth" "$APP" "allowed-ips" "$ADDRESS"
+  fn-http-auth-template-config "$APP"
+  validate_nginx "$APP" && restart_nginx "$APP" >/dev/null
+}
+
+fn-http-auth-warn-ip-domain-overlap() {
+  declare desc="warn that allowed-ips remain app-wide even when auth is scoped to domains"
+
+  dokku_log_warn "allowed-ips apply to all domains; domains without auth will still reject non-allowed IPs with 403"
+}
+
+cmd-http-auth-add-domain() {
+  declare desc="restrict basic auth to a specific domain for an app"
+  declare cmd="http-auth:add-domain"
+  [[ "$1" == "$cmd" ]] && shift 1
+  declare APP="$1" DOMAIN="$2"
+
+  if [[ -z "$DOMAIN" ]]; then
+    dokku_log_fail "Missing domain"
+    return 1
+  fi
+
+  verify_app_name "$APP"
+  DOMAIN="$(fn-http-auth-normalize-domain "$DOMAIN")"
+  if ! fn-http-auth-domain-attached "$APP" "$DOMAIN"; then
+    dokku_log_fail "$DOMAIN is not a domain of $APP"
+  fi
+
+  dokku_log_info1 "Adding $DOMAIN to auth domain list"
+  if fn-plugin-property-list-get-by-value "http-auth" "$APP" "auth-domains" "$DOMAIN" 2>/dev/null; then
+    return
+  fi
+
+  fn-plugin-property-list-add "http-auth" "$APP" "auth-domains" "$DOMAIN"
+  fn-plugin-property-write "http-auth" "$APP" "enabled" "true"
+  if fn-http-auth-has-allowed-ips "$APP"; then
+    fn-http-auth-warn-ip-domain-overlap
+  fi
+  fn-http-auth-template-config "$APP"
+  validate_nginx "$APP" && restart_nginx "$APP" >/dev/null
+}
+
+cmd-http-auth-remove-domain() {
+  declare desc="stop restricting basic auth to a specific domain for an app"
+  declare cmd="http-auth:remove-domain"
+  [[ "$1" == "$cmd" ]] && shift 1
+  declare APP="$1" DOMAIN="$2"
+
+  verify_app_name "$APP"
+
+  if [[ -z "$DOMAIN" ]]; then
+    dokku_log_fail "Missing domain"
+    return 1
+  fi
+
+  DOMAIN="$(fn-http-auth-normalize-domain "$DOMAIN")"
+  dokku_log_info1 "Removing $DOMAIN from auth domain list"
+  fn-plugin-property-list-remove "http-auth" "$APP" "auth-domains" "$DOMAIN"
+  fn-http-auth-template-config "$APP"
+  validate_nginx "$APP" && restart_nginx "$APP" >/dev/null
+}
+
+cmd-http-auth-set-domains() {
+  declare desc="replace the set of domains basic auth is restricted to for an app"
+  declare cmd="http-auth:set-domains"
+  [[ "$1" == "$cmd" ]] && shift 1
+  declare APP="$1"
+
+  verify_app_name "$APP"
+  shift 1
+
+  local domain existing
+  local domains=()
+  # validate every domain before mutating so a bad domain never leaves a half-set list
+  for domain in "$@"; do
+    domain="$(fn-http-auth-normalize-domain "$domain")"
+    if ! fn-http-auth-domain-attached "$APP" "$domain"; then
+      dokku_log_fail "$domain is not a domain of $APP"
+    fi
+    domains+=("$domain")
+  done
+
+  dokku_log_info1 "Setting auth domain list for $APP"
+  while IFS="" read -r existing || [[ -n "$existing" ]]; do
+    [[ -n "$existing" ]] && fn-plugin-property-list-remove "http-auth" "$APP" "auth-domains" "$existing"
+  done < <(fn-plugin-property-list-get "http-auth" "$APP" "auth-domains")
+
+  for domain in "${domains[@]}"; do
+    fn-plugin-property-list-add "http-auth" "$APP" "auth-domains" "$domain"
+  done
+
+  if [[ "${#domains[@]}" -gt 0 ]]; then
+    fn-plugin-property-write "http-auth" "$APP" "enabled" "true"
+    if fn-http-auth-has-allowed-ips "$APP"; then
+      fn-http-auth-warn-ip-domain-overlap
+    fi
+  fi
+
   fn-http-auth-template-config "$APP"
   validate_nginx "$APP" && restart_nginx "$APP" >/dev/null
 }

--- a/help-functions
+++ b/help-functions
@@ -29,11 +29,14 @@ fn-help-content() {
   cat <<help_content
     http-auth:add-user <app> <user> <password>, Add basic auth user to app
     http-auth:add-allowed-ip <app> <address>, add allowed ip to basic auth bypass for an app
+    http-auth:add-domain <app> <domain>, restrict basic auth to the given domain (empty list = all domains)
     http-auth:disable <app>, Disable HTTP auth for app
     http-auth:enable <app> [<user>] [<password>], Enable HTTP auth for app
     http-auth:remove-allowed-ip <app> <address>, remove allowed ip from basic auth bypass for an app
+    http-auth:remove-domain <app> <domain>, stop restricting basic auth to the given domain
     http-auth:remove-user <app> <user>, Remove basic auth user from app
     http-auth:report [<app>] [<flag>], Displays an http-auth report for one or more apps
+    http-auth:set-domains <app> [<domain>...], replace the set of domains basic auth is restricted to
     http-auth:show-config <app>, Display app http-auth config
 help_content
 }

--- a/internal-functions
+++ b/internal-functions
@@ -105,16 +105,57 @@ fn-http-auth-template-config() {
   declare APP="$1"
   local APP_ROOT="$DOKKU_ROOT/$APP"
   local DOKKU_TEMPLATE="$PLUGIN_AVAILABLE_PATH/http-auth/templates/http-auth.conf"
-  local HTPASSWD_PATH ALLOWED_IPS
+  local HTPASSWD_PATH ALLOWED_IPS AUTH_DOMAINS
 
   fn-http-auth-ensure-htpasswd "$APP"
   HTPASSWD_PATH="$(fn-http-auth-htpasswd-path "$APP")"
   # `local` keeps the failing `test -s` (empty htpasswd) from tripping `set -e`
   local HAS_ALLOWED_USERS="$(test -s "$HTPASSWD_PATH" && echo "true")"
   ALLOWED_IPS="$(fn-plugin-property-list-get "http-auth" "$APP" "allowed-ips" | xargs)"
+  AUTH_DOMAINS="$(fn-plugin-property-list-get "http-auth" "$APP" "auth-domains" | xargs)"
   mkdir -p "$APP_ROOT/nginx.conf.d"
 
-  sigil -f "$DOKKU_TEMPLATE" HTPASSWD_PATH="$HTPASSWD_PATH" ALLOWED_IPS="$ALLOWED_IPS" HAS_ALLOWED_USERS="$HAS_ALLOWED_USERS" | cat -s >"$APP_ROOT/nginx.conf.d/http-auth.conf"
+  sigil -f "$DOKKU_TEMPLATE" HTPASSWD_PATH="$HTPASSWD_PATH" ALLOWED_IPS="$ALLOWED_IPS" AUTH_DOMAINS="$AUTH_DOMAINS" HAS_ALLOWED_USERS="$HAS_ALLOWED_USERS" | cat -s >"$APP_ROOT/nginx.conf.d/http-auth.conf"
+}
+
+fn-http-auth-app-vhosts() {
+  declare desc="list the nginx vhosts currently attached to an app"
+  declare APP="$1"
+
+  dokku domains:report "$APP" --domains-app-vhosts 2>/dev/null || true
+}
+
+fn-http-auth-domain-attached() {
+  declare desc="check whether a domain is one of the app's nginx vhosts"
+  declare APP="$1" DOMAIN="$2"
+  local vhost
+
+  for vhost in $(fn-http-auth-app-vhosts "$APP"); do
+    [[ "$vhost" == "$DOMAIN" ]] && return 0
+  done
+
+  return 1
+}
+
+fn-http-auth-normalize-domain() {
+  declare desc="lowercase a domain so it matches nginx's lowercased \$host"
+  declare DOMAIN="$1"
+
+  echo "$DOMAIN" | tr '[:upper:]' '[:lower:]'
+}
+
+fn-http-auth-has-allowed-ips() {
+  declare desc="check whether an app has any allowed ips configured"
+  declare APP="$1"
+
+  [[ -n "$(fn-plugin-property-list-get "http-auth" "$APP" "allowed-ips" | xargs)" ]]
+}
+
+fn-http-auth-has-auth-domains() {
+  declare desc="check whether an app restricts auth to specific domains"
+  declare APP="$1"
+
+  [[ -n "$(fn-plugin-property-list-get "http-auth" "$APP" "auth-domains" | xargs)" ]]
 }
 
 fn-http-auth-migrate-enabled() {

--- a/subcommands/add-domain
+++ b/subcommands/add-domain
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+source "$PLUGIN_AVAILABLE_PATH/http-auth/command-functions"
+set -eo pipefail
+[[ $DOKKU_TRACE ]] && set -x
+
+cmd-http-auth-add-domain "$@"

--- a/subcommands/remove-domain
+++ b/subcommands/remove-domain
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+source "$PLUGIN_AVAILABLE_PATH/http-auth/command-functions"
+set -eo pipefail
+[[ $DOKKU_TRACE ]] && set -x
+
+cmd-http-auth-remove-domain "$@"

--- a/subcommands/set-domains
+++ b/subcommands/set-domains
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+source "$PLUGIN_AVAILABLE_PATH/http-auth/command-functions"
+set -eo pipefail
+[[ $DOKKU_TRACE ]] && set -x
+
+cmd-http-auth-set-domains "$@"

--- a/templates/http-auth.conf
+++ b/templates/http-auth.conf
@@ -7,6 +7,17 @@ deny all;
 {{ end }}
 
 {{ if $HAS_ALLOWED_USERS }}
+{{ if $AUTH_DOMAINS }}
+set $dokku_auth_realm off;
+{{ range $auth_domain := .AUTH_DOMAINS | split " " }}
+if ($host = "{{ $auth_domain }}") {
+  set $dokku_auth_realm "Restricted";
+}
+{{ end }}
+auth_basic           $dokku_auth_realm;
+auth_basic_user_file {{ $.HTPASSWD_PATH }};
+{{ else }}
 auth_basic           "Restricted";
 auth_basic_user_file {{ $.HTPASSWD_PATH }};
+{{ end }}
 {{ end }}

--- a/tests/http_auth_allowed_ips.bats
+++ b/tests/http_auth_allowed_ips.bats
@@ -101,3 +101,11 @@ teardown() {
   run http_auth_conf "$APP"
   [[ "$output" == *"allow 10.0.0.5;"* ]]
 }
+
+@test "(http-auth:add-allowed-ip) warns when the app restricts auth to domains" {
+  dokku domains:add "$APP" a.example.com >/dev/null
+  dokku http-auth:add-domain "$APP" a.example.com
+  run dokku http-auth:add-allowed-ip "$APP" 10.0.0.6
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"allowed-ips apply to all domains"* ]]
+}

--- a/tests/http_auth_domains.bats
+++ b/tests/http_auth_domains.bats
@@ -1,0 +1,176 @@
+#!/usr/bin/env bats
+
+load 'test_helper'
+
+setup() {
+  APP="$(new_app_name)"
+  create_app "$APP"
+  # attach vhosts so add-domain/set-domains validation (which checks the app's
+  # actual domains) has something to match; the suite never deploys.
+  dokku domains:add "$APP" a.example.com b.example.com >/dev/null
+  dokku http-auth:enable "$APP" u1 pass1
+}
+
+teardown() {
+  cleanup_app "$APP"
+}
+
+@test "(http-auth:add-domain) renders a host-gated realm variable" {
+  run dokku http-auth:add-domain "$APP" a.example.com
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Adding a.example.com to auth domain list"* ]]
+  run http_auth_conf "$APP"
+  [[ "$output" == *'set $dokku_auth_realm off;'* ]]
+  [[ "$output" == *'if ($host = "a.example.com") {'* ]]
+  [[ "$output" == *'set $dokku_auth_realm "Restricted";'* ]]
+  [[ "$output" == *'auth_basic           $dokku_auth_realm;'* ]]
+  [[ "$output" == *"auth_basic_user_file $(htpasswd_path "$APP");"* ]]
+  # the plain app-wide realm must not be present when domains are set
+  [[ "$output" != *'auth_basic           "Restricted";'* ]]
+}
+
+@test "(http-auth) with no domains renders the plain auth_basic block" {
+  run http_auth_conf "$APP"
+  [[ "$output" == *'auth_basic           "Restricted";'* ]]
+  [[ "$output" != *'dokku_auth_realm'* ]]
+}
+
+@test "(http-auth:add-domain) renders one if block per domain" {
+  dokku http-auth:add-domain "$APP" a.example.com
+  dokku http-auth:add-domain "$APP" b.example.com
+  run http_auth_conf "$APP"
+  [[ "$output" == *'if ($host = "a.example.com") {'* ]]
+  [[ "$output" == *'if ($host = "b.example.com") {'* ]]
+}
+
+@test "(http-auth:add-domain) is idempotent for duplicate domains" {
+  dokku http-auth:add-domain "$APP" a.example.com
+  run dokku http-auth:add-domain "$APP" a.example.com
+  [ "$status" -eq 0 ]
+  [ "$(http_auth_conf "$APP" | grep -c 'if (\$host = "a.example.com") {')" -eq 1 ]
+  run dokku http-auth:report "$APP" --http-auth-domains
+  [ "$status" -eq 0 ]
+  [ "$output" = "a.example.com" ]
+}
+
+@test "(http-auth:add-domain) lowercases the domain" {
+  run dokku http-auth:add-domain "$APP" A.Example.COM
+  [ "$status" -eq 0 ]
+  run http_auth_conf "$APP"
+  [[ "$output" == *'if ($host = "a.example.com") {'* ]]
+  [[ "$output" != *"A.Example.COM"* ]]
+  run dokku http-auth:report "$APP" --http-auth-domains
+  [ "$output" = "a.example.com" ]
+}
+
+@test "(http-auth:add-domain) fails when the domain is not attached to the app" {
+  run dokku http-auth:add-domain "$APP" nope.example.com
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"nope.example.com is not a domain of $APP"* ]]
+}
+
+@test "(http-auth:add-domain) fails when the domain is missing" {
+  run dokku http-auth:add-domain "$APP"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Missing domain"* ]]
+}
+
+@test "(http-auth:add-domain) on a disabled app implicitly enables auth" {
+  dokku http-auth:disable "$APP"
+  assert_disabled "$APP"
+  run dokku http-auth:add-domain "$APP" a.example.com
+  [ "$status" -eq 0 ]
+  assert_enabled "$APP"
+  run http_auth_conf "$APP"
+  [[ "$output" == *'if ($host = "a.example.com") {'* ]]
+}
+
+@test "(http-auth:add-domain) warns when the app already has allowed ips" {
+  dokku http-auth:add-allowed-ip "$APP" 10.0.0.1
+  run dokku http-auth:add-domain "$APP" a.example.com
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"allowed-ips apply to all domains"* ]]
+}
+
+@test "(http-auth:add-domain) combined with allowed ips renders both blocks" {
+  dokku http-auth:add-allowed-ip "$APP" 10.0.0.1
+  dokku http-auth:add-domain "$APP" a.example.com
+  run http_auth_conf "$APP"
+  [[ "$output" == *"satisfy any;"* ]]
+  [[ "$output" == *"allow 10.0.0.1;"* ]]
+  [[ "$output" == *"deny all;"* ]]
+  [[ "$output" == *'if ($host = "a.example.com") {'* ]]
+  [[ "$output" == *'auth_basic           $dokku_auth_realm;'* ]]
+}
+
+@test "(http-auth:set-domains) replaces the domain list" {
+  dokku http-auth:add-domain "$APP" a.example.com
+  run dokku http-auth:set-domains "$APP" b.example.com
+  [ "$status" -eq 0 ]
+  run http_auth_conf "$APP"
+  [[ "$output" == *'if ($host = "b.example.com") {'* ]]
+  [[ "$output" != *'if ($host = "a.example.com") {'* ]]
+  run dokku http-auth:report "$APP" --http-auth-domains
+  [ "$output" = "b.example.com" ]
+}
+
+@test "(http-auth:set-domains) with no domains clears back to the plain block" {
+  dokku http-auth:add-domain "$APP" a.example.com
+  run dokku http-auth:set-domains "$APP"
+  [ "$status" -eq 0 ]
+  run http_auth_conf "$APP"
+  [[ "$output" == *'auth_basic           "Restricted";'* ]]
+  [[ "$output" != *'dokku_auth_realm'* ]]
+  run dokku http-auth:report "$APP" --http-auth-domains
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "(http-auth:set-domains) fails when any domain is not attached" {
+  run dokku http-auth:set-domains "$APP" a.example.com nope.example.com
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"nope.example.com is not a domain of $APP"* ]]
+  # the whole operation must be rejected, leaving no domains set
+  run dokku http-auth:report "$APP" --http-auth-domains
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "(http-auth:remove-domain) removes only the targeted if block" {
+  dokku http-auth:add-domain "$APP" a.example.com
+  dokku http-auth:add-domain "$APP" b.example.com
+  run dokku http-auth:remove-domain "$APP" a.example.com
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Removing a.example.com from auth domain list"* ]]
+  run http_auth_conf "$APP"
+  [[ "$output" != *'if ($host = "a.example.com") {'* ]]
+  [[ "$output" == *'if ($host = "b.example.com") {'* ]]
+}
+
+@test "(http-auth:remove-domain) removing the last domain restores the plain block" {
+  dokku http-auth:add-domain "$APP" a.example.com
+  dokku http-auth:remove-domain "$APP" a.example.com
+  run http_auth_conf "$APP"
+  [[ "$output" == *'auth_basic           "Restricted";'* ]]
+  [[ "$output" != *'dokku_auth_realm'* ]]
+}
+
+@test "(http-auth:remove-domain) fails when the domain is missing" {
+  run dokku http-auth:remove-domain "$APP"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Missing domain"* ]]
+}
+
+@test "(http-auth:report) --http-auth-domains lists domains" {
+  dokku http-auth:add-domain "$APP" a.example.com
+  dokku http-auth:add-domain "$APP" b.example.com
+  run dokku http-auth:report "$APP" --http-auth-domains
+  [ "$status" -eq 0 ]
+  [ "$output" = "a.example.com b.example.com" ]
+}
+
+@test "(http-auth:report) --http-auth-domains is empty but successful with no domains" {
+  run dokku http-auth:report "$APP" --http-auth-domains
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}

--- a/tests/http_auth_help.bats
+++ b/tests/http_auth_help.bats
@@ -11,7 +11,7 @@ load 'test_helper'
 @test "(http-auth:help) lists every subcommand" {
   run dokku http-auth:help
   [ "$status" -eq 0 ]
-  for subcommand in add-allowed-ip add-user disable enable remove-allowed-ip remove-user report show-config; do
+  for subcommand in add-allowed-ip add-domain add-user disable enable remove-allowed-ip remove-domain remove-user report set-domains show-config; do
     [[ "$output" == *"http-auth:${subcommand}"* ]]
   done
 }

--- a/tests/http_auth_hooks.bats
+++ b/tests/http_auth_hooks.bats
@@ -42,6 +42,20 @@ teardown() {
   [[ "$output" == *"auth_basic_user_file $(htpasswd_path "$APP2");"* ]]
 }
 
+@test "(http-auth) post-app-clone-setup clones auth domains to the new app" {
+  APP2="$(new_app_name)"
+  dokku domains:add "$APP" a.example.com >/dev/null
+  dokku http-auth:enable "$APP" u1 pass1
+  dokku http-auth:add-domain "$APP" a.example.com
+  dokku apps:clone --skip-deploy "$APP" "$APP2"
+  run dokku http-auth:report "$APP2" --http-auth-domains
+  [ "$status" -eq 0 ]
+  [ "$output" = "a.example.com" ]
+  # the include re-renders with the host-gated block for the cloned app
+  run http_auth_conf "$APP2"
+  [[ "$output" == *'if ($host = "a.example.com") {'* ]]
+}
+
 @test "(http-auth) post-app-rename-setup moves properties and htpasswd to the new name" {
   APP2="$(new_app_name)"
   dokku http-auth:enable "$APP" u1 pass1

--- a/tests/http_auth_report.bats
+++ b/tests/http_auth_report.bats
@@ -17,6 +17,7 @@ teardown() {
   [[ "$output" == *"$APP http-auth information"* ]]
   [[ "$output" == *"Http auth enabled"* ]]
   [[ "$output" == *"Http auth allowed ips"* ]]
+  [[ "$output" == *"Http auth domains"* ]]
   [[ "$output" == *"Http auth users"* ]]
 }
 


### PR DESCRIPTION
Basic auth previously applied to every domain attached to an app, so an app serving multiple domains prompted for credentials on all of them. This adds `http-auth:add-domain`, `http-auth:remove-domain`, and `http-auth:set-domains` to restrict the auth prompt to a chosen set of the app's domains, leaving the rest public. When no domains are configured auth stays app-wide, so existing setups are unaffected.

Domains are validated against the app's attached vhosts and rejected if not present. Because allowed IPs cannot be scoped per-domain in nginx, the plugin warns when allowed IPs and domain restrictions are combined.

Closes #20.