### PR TITLE
feat: add --format json support to http-auth:report

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -6,3 +6,5 @@ disable=SC2034
 disable=SC2086
 # SC2155: declare-and-assign is the established style here
 disable=SC2155
+# SC2178: bash nameref via `local -n` is intentionally an array reference
+disable=SC2178

--- a/README.md
+++ b/README.md
@@ -227,6 +227,18 @@ You can pass flags which will output only the value of the specific information 
 dokku http-auth:report node-js-app --http-auth-enabled
 ```
 
+The report can also be emitted as JSON for programmatic use by passing `--format json`:
+
+```shell
+# dokku http-auth:report node-js-app --format json
+```
+
+```json
+{"enabled":"true","allowed-ips":"127.0.0.1","domains":"secure.example.com","users":"root username"}
+```
+
+All values are JSON strings, and list values (`allowed-ips`, `domains`, `users`) are space-joined, matching the human-readable rows. The `--format json` flag cannot be combined with an individual info flag. Passing `--global` reports global properties only; since http-auth has no global properties, `http-auth:report --global --format json` returns `{}`.
+
 ### How state is persisted
 
 Whether HTTP auth is enabled for an app is tracked as an app property, and the generated nginx include (`nginx.conf.d/http-auth.conf`) is regenerated from that state on every deploy. This keeps the include in sync with the configured users and allowed IPs, and restores it automatically if it was ever left empty or out of date.

--- a/command-functions
+++ b/command-functions
@@ -10,7 +10,10 @@ cmd-http-auth-report() {
   declare desc="displays a http-auth report for one or more apps"
   declare cmd="http-auth:report"
   [[ "$1" == "$cmd" ]] && shift 1
-  declare APP="$1" INFO_FLAG="$2"
+  fn-http-auth-report-parse-args "$@"
+  set -- "${REPORT_ARGS[@]}"
+
+  declare APP="${1:-}" INFO_FLAG="${2:-}"
   local INSTALLED_APPS
   INSTALLED_APPS=$(dokku_apps)
 
@@ -19,25 +22,33 @@ cmd-http-auth-report() {
     APP=""
   fi
 
+  if [[ "$REPORT_IS_GLOBAL" == "true" ]]; then
+    APP="--global"
+  fi
+
   if [[ -z "$APP" ]] && [[ -z "$INFO_FLAG" ]]; then
     INFO_FLAG="true"
   fi
 
-  if [[ -z "$APP" ]]; then
+  if [[ "$APP" == "--global" ]]; then
+    cmd-http-auth-report-single "$APP" "$INFO_FLAG" "$REPORT_FORMAT"
+  elif [[ -z "$APP" ]]; then
     for app in $INSTALLED_APPS; do
-      cmd-http-auth-report-single "$app" "$INFO_FLAG" | tee || true
+      cmd-http-auth-report-single "$app" "$INFO_FLAG" "$REPORT_FORMAT" | tee || true
     done
   else
-    cmd-http-auth-report-single "$APP" "$INFO_FLAG"
+    cmd-http-auth-report-single "$APP" "$INFO_FLAG" "$REPORT_FORMAT"
   fi
 }
 
 cmd-http-auth-report-single() {
-  declare APP="$1" INFO_FLAG="$2"
+  declare APP="$1" INFO_FLAG="$2" FORMAT="${3:-stdout}"
   if [[ "$INFO_FLAG" == "true" ]]; then
     INFO_FLAG=""
   fi
-  verify_app_name "$APP"
+  if [[ "$APP" != "--global" ]]; then
+    verify_app_name "$APP"
+  fi
   local flag_map=(
     "--http-auth-enabled: $(fn-http-auth-enabled "$APP")"
     "--http-auth-allowed-ips: $(fn-plugin-property-list-get "http-auth" "$APP" "allowed-ips" | xargs)"
@@ -45,8 +56,23 @@ cmd-http-auth-report-single() {
     "--http-auth-users: $(fn-http-auth-list-users "$APP" | xargs)"
   )
 
+  if [[ "$APP" == "--global" ]]; then
+    fn-http-auth-report-filter-global flag_map
+  fi
+
+  fn-http-auth-report-validate-format "$FORMAT" "$INFO_FLAG"
+
+  if [[ "$FORMAT" == "json" ]]; then
+    fn-http-auth-report-emit-json flag_map
+    return
+  fi
+
   if [[ -z "$INFO_FLAG" ]]; then
-    dokku_log_info2_quiet "${APP} http-auth information"
+    if [[ "$APP" == "--global" ]]; then
+      dokku_log_info2_quiet "global http-auth information"
+    else
+      dokku_log_info2_quiet "${APP} http-auth information"
+    fi
     for flag in "${flag_map[@]}"; do
       key="$(echo "${flag#--}" | cut -f1 -d' ' | tr - ' ')"
       dokku_log_verbose "$(printf "%-30s %-25s" "${key^}" "${flag#*: }")"

--- a/help-functions
+++ b/help-functions
@@ -35,7 +35,7 @@ fn-help-content() {
     http-auth:remove-allowed-ip <app> <address>, remove allowed ip from basic auth bypass for an app
     http-auth:remove-domain <app> <domain>, stop restricting basic auth to the given domain
     http-auth:remove-user <app> <user>, Remove basic auth user from app
-    http-auth:report [<app>] [<flag>], Displays an http-auth report for one or more apps
+    http-auth:report [<app>] [<flag>] [--format stdout|json], Displays an http-auth report for one or more apps
     http-auth:set-domains <app> [<domain>...], replace the set of domains basic auth is restricted to
     http-auth:show-config <app>, Display app http-auth config
 help_content

--- a/internal-functions
+++ b/internal-functions
@@ -193,3 +193,67 @@ fn-http-auth-migrate-htpasswd-all() {
     { nginx -t >/dev/null 2>&1 && fn-nginx-vhosts-nginx-init-cmd reload; } || true
   fi
 }
+
+# The report helpers below are defined locally rather than delegating to dokku
+# core's fn-report-* so the report keeps working on older Dokku releases that
+# predate them, matching the convention in dokku-letsencrypt and dokku-maintenance.
+
+fn-http-auth-report-parse-args() {
+  declare desc="strip --format and --global from a report invocation"
+  REPORT_FORMAT="stdout"
+  REPORT_IS_GLOBAL="false"
+  REPORT_ARGS=()
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --format)
+        REPORT_FORMAT="$2"
+        shift 2
+        ;;
+      --global)
+        REPORT_IS_GLOBAL="true"
+        shift
+        ;;
+      *)
+        REPORT_ARGS+=("$1")
+        shift
+        ;;
+    esac
+  done
+}
+
+fn-http-auth-report-validate-format() {
+  declare desc="reject --format when combined with an info flag"
+  declare FORMAT="$1" INFO_FLAG="$2"
+  if [[ "$FORMAT" != "stdout" ]] && [[ -n "$INFO_FLAG" ]]; then
+    dokku_log_fail "--format flag cannot be specified when specifying an info flag"
+  fi
+}
+
+fn-http-auth-report-filter-global() {
+  declare desc="rewrite flag_map keeping only --http-auth-global-* entries"
+  declare flag_map_name="$1"
+  local -n flag_map_ref="$flag_map_name"
+  local filtered=()
+  local flag key
+  for flag in "${flag_map_ref[@]}"; do
+    key="$(echo "$flag" | cut -d':' -f1)"
+    if [[ "$key" == *"-global-"* ]]; then
+      filtered+=("$flag")
+    fi
+  done
+  flag_map_ref=("${filtered[@]}")
+}
+
+fn-http-auth-report-emit-json() {
+  declare desc="emit a flag_map as a JSON object, stripping the --http-auth- key prefix"
+  declare flag_map_name="$1"
+  local -n flag_map_ref="$flag_map_name"
+  local json_output="{}"
+  local flag key value
+  for flag in "${flag_map_ref[@]}"; do
+    key="$(echo "$flag" | cut -d':' -f1 | sed 's/^--http-auth-//')"
+    value="$(echo "$flag" | cut -d':' -f2- | sed 's/^ //')"
+    json_output="$(echo "$json_output" | jq -c --arg key "$key" --arg value "$value" '. + {($key): $value}')"
+  done
+  echo "$json_output"
+}

--- a/tests/http_auth_report.bats
+++ b/tests/http_auth_report.bats
@@ -73,3 +73,48 @@ teardown() {
   [ "$status" -ne 0 ]
   [[ "$output" == *"does not exist"* ]]
 }
+
+@test "(http-auth:report) --format json emits a json object" {
+  run dokku http-auth:report "$APP" --format json
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"enabled":"false"'* ]]
+  [[ "$output" == *'"allowed-ips":""'* ]]
+  [[ "$output" == *'"domains":""'* ]]
+  [[ "$output" == *'"users":""'* ]]
+
+  dokku http-auth:enable "$APP"
+  dokku http-auth:add-allowed-ip "$APP" 10.0.0.1
+
+  run dokku http-auth:report "$APP" --format json
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"enabled":"true"'* ]]
+  [[ "$output" == *'"allowed-ips":"10.0.0.1"'* ]]
+}
+
+@test "(http-auth:report) --format json rejects an info flag" {
+  run dokku http-auth:report "$APP" --format json --http-auth-enabled
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"--format flag cannot be specified when specifying an info flag"* ]]
+}
+
+@test "(http-auth:report) without an app emits one json object per app" {
+  run dokku http-auth:report --format json
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"enabled":"false"'* ]]
+
+  # every emitted line is a valid JSON object
+  run /bin/bash -c "dokku http-auth:report --format json | jq -e . >/dev/null"
+  [ "$status" -eq 0 ]
+}
+
+@test "(http-auth:report) --global --format json returns an empty object" {
+  run dokku http-auth:report --global --format json
+  [ "$status" -eq 0 ]
+  [ "$output" = "{}" ]
+}
+
+@test "(dokku report) includes an http-auth section" {
+  run dokku report "$APP"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"http-auth information"* ]]
+}


### PR DESCRIPTION
Aligns `http-auth:report` with the report output standardization used across Dokku and its plugins, adding `--format stdout|json` and `--global` support so the report can be consumed programmatically while leaving the existing human-readable output unchanged.