### PR TITLE
feat: add http-auth:export-users and import-users

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ $ dokku http-auth:help
     http-auth:add-domain <app> <domain>         Restrict basic auth to the given domain (empty list = all domains)
     http-auth:disable <app>                     Disable HTTP auth for app
     http-auth:enable <app> <user> <password>    Enable HTTP auth for app
+    http-auth:export-users <app>                Export basic auth users as htpasswd entries to stdout
+    http-auth:import-users <app> [--replace]    Import basic auth users from stdin (htpasswd entries)
     http-auth:remove-allowed-ip <app> <address> Remove allowed IP from basic auth bypass for an app
     http-auth:remove-domain <app> <domain>      Stop restricting basic auth to the given domain
     http-auth:remove-user <app> <user>          Remove basic auth user from app
@@ -95,6 +97,43 @@ dokku http-auth:remove-user node-js-app username
 -----> Creating https nginx.conf
        Enabling HSTS
        Reloading nginx
+```
+
+### Exporting users
+
+The `http-auth:export-users` command streams an app's basic auth credentials to stdout as htpasswd `user:hash` entries. This is the inverse of `http-auth:add-user`: because the entries carry the stored SHA-512 hashes (never the plaintext passwords), they can be saved or re-applied to another app or server without knowing the original passwords. Only the entries are written to stdout, so the output can be redirected to a file or piped straight into `http-auth:import-users`.
+
+```shell
+# dokku http-auth:export-users node-js-app > users.htpasswd            # Server side
+$ ssh dokku@server http-auth:export-users node-js-app > users.htpasswd # Client side
+```
+
+```
+username:$6$Xm3kx1s9$Zq8...
+```
+
+Export works even when auth is disabled, since the credentials persist. If the app has no users, the command still exits successfully but writes nothing to stdout and prints a notice to stderr.
+
+### Importing users
+
+The `http-auth:import-users` command reads htpasswd `user:hash` entries from stdin and applies them to an app, enabling HTTP auth if it was not already enabled. By default it upserts: each imported user is added or has its password updated by username, and any other existing users are left in place. Pass `--replace` to make the app's users exactly the imported set instead.
+
+```shell
+dokku http-auth:import-users node-js-app < users.htpasswd
+```
+
+```
+-----> Importing 2 http-auth user(s) for node-js-app
+-----> Configuring node-js-app.dokku.me...(using built-in template)
+-----> Creating https nginx.conf
+       Enabling HSTS
+       Reloading nginx
+```
+
+Paired with `http-auth:export-users`, this moves credentials between hosts without ever exposing the plaintext passwords:
+
+```shell
+ssh dokku@old-server http-auth:export-users node-js-app | ssh dokku@new-server http-auth:import-users node-js-app
 ```
 
 ### Limiting access to specific IP Addresses

--- a/command-functions
+++ b/command-functions
@@ -246,6 +246,82 @@ cmd-http-auth-remove-user() {
   validate_nginx "$APP" && restart_nginx "$APP" >/dev/null
 }
 
+cmd-http-auth-export-users() {
+  declare desc="export http auth users as htpasswd entries to stdout"
+  declare cmd="http-auth:export-users"
+  [[ "$1" == "$cmd" ]] && shift 1
+  declare APP="$1"
+
+  verify_app_name "$APP"
+
+  # deliberately not gated on the enabled state: disabling an app leaves its
+  # htpasswd in place, and the whole point is to read those credentials back
+  # out for migration regardless of whether auth is currently serving
+  local CONTENTS
+  CONTENTS="$(fn-http-auth-current-htpasswd "$APP")"
+  if [[ -z "$CONTENTS" ]]; then
+    dokku_log_warn "No http-auth users set for $APP; nothing to export"
+    return 0
+  fi
+
+  # only the htpasswd entries reach stdout (no dokku_log_info*, which prints
+  # there) so the output can be piped straight into http-auth:import-users
+  printf '%s\n' "$CONTENTS"
+}
+
+cmd-http-auth-import-users() {
+  declare desc="import http auth users from stdin as htpasswd entries"
+  declare cmd="http-auth:import-users"
+  [[ "$1" == "$cmd" ]] && shift 1
+
+  local REPLACE=false
+  local positional=()
+  local arg
+  for arg in "$@"; do
+    case "$arg" in
+      --replace)
+        REPLACE=true
+        ;;
+      *)
+        positional+=("$arg")
+        ;;
+    esac
+  done
+  set -- "${positional[@]}"
+  declare APP="$1"
+
+  verify_app_name "$APP"
+
+  if [[ -t 0 ]]; then
+    dokku_log_fail "htpasswd entries (user:hash) expected on stdin"
+  fi
+
+  # validate everything before writing anything so a malformed line never
+  # leaves a half-written htpasswd; the here-string keeps the loop in the
+  # current shell so dokku_log_fail's exit propagates out of the command
+  local INPUT entries=() line
+  INPUT="$(cat)"
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    [[ -z "$line" ]] && continue
+    if [[ ! "$line" =~ ^[^:]+:.+$ ]]; then
+      dokku_log_fail "Invalid htpasswd entry: $line"
+    fi
+    entries+=("$line")
+  done <<< "$INPUT"
+
+  if [[ "${#entries[@]}" -eq 0 ]]; then
+    dokku_log_fail "No htpasswd entries provided on stdin"
+  fi
+
+  dokku_log_info1 "Importing ${#entries[@]} http-auth user(s) for $APP"
+  printf '%s\n' "${entries[@]}" | fn-http-auth-import-users "$APP" "$REPLACE"
+  # adding auth config turns auth on, matching add-allowed-ip/add-domain, and
+  # guarantees the template render below never resurrects auth on a disabled app
+  fn-plugin-property-write "http-auth" "$APP" "enabled" "true"
+  fn-http-auth-template-config "$APP"
+  validate_nginx "$APP" && restart_nginx "$APP" >/dev/null
+}
+
 cmd-http-auth-remove-allowed-ip() {
   declare desc="remove allowed ip from basic auth bypass for an app"
   declare cmd="http-auth:remove-allowed-ip"

--- a/help-functions
+++ b/help-functions
@@ -32,6 +32,8 @@ fn-help-content() {
     http-auth:add-domain <app> <domain>, restrict basic auth to the given domain (empty list = all domains)
     http-auth:disable <app>, Disable HTTP auth for app
     http-auth:enable <app> [<user>] [<password>], Enable HTTP auth for app
+    http-auth:export-users <app>, Export basic auth users as htpasswd entries to stdout
+    http-auth:import-users <app> [--replace], Import basic auth users from stdin (htpasswd entries)
     http-auth:remove-allowed-ip <app> <address>, remove allowed ip from basic auth bypass for an app
     http-auth:remove-domain <app> <domain>, stop restricting basic auth to the given domain
     http-auth:remove-user <app> <user>, Remove basic auth user from app

--- a/internal-functions
+++ b/internal-functions
@@ -101,6 +101,35 @@ fn-http-auth-remove-user() {
   fn-http-auth-current-htpasswd "$APP" | sed "/^${AUTH_USERNAME}:/d" | fn-http-auth-set-htpasswd "$APP"
 }
 
+fn-http-auth-import-users() {
+  declare desc="write imported user:hash entries from stdin to the htpasswd, upserting by default or replacing existing users"
+  declare APP="$1" REPLACE="${2:-false}"
+  local IMPORTED
+  IMPORTED="$(cat)"
+
+  if [[ "$REPLACE" == "true" ]]; then
+    printf '%s\n' "$IMPORTED" | fn-http-auth-set-htpasswd "$APP"
+    return
+  fi
+
+  # upsert: drop any existing line whose username matches an imported one, then
+  # append the imported entries so they win on collision (like fn-http-auth-add-user).
+  # awk with -F: and an exact $1 comparison avoids sed metacharacter issues in
+  # usernames and its NF guard drops the blank line an empty $KEPT would emit.
+  local KEPT USERNAMES USERNAME
+  KEPT="$(fn-http-auth-current-htpasswd "$APP")"
+  USERNAMES="$(printf '%s\n' "$IMPORTED" | cut -d':' -f1)"
+  while IFS= read -r USERNAME || [[ -n "$USERNAME" ]]; do
+    [[ -z "$USERNAME" ]] && continue
+    KEPT="$(printf '%s\n' "$KEPT" | awk -F: -v u="$USERNAME" 'NF && $1 != u')"
+  done <<< "$USERNAMES"
+
+  {
+    [[ -n "$KEPT" ]] && printf '%s\n' "$KEPT"
+    printf '%s\n' "$IMPORTED"
+  } | fn-http-auth-set-htpasswd "$APP"
+}
+
 fn-http-auth-template-config() {
   declare APP="$1"
   local APP_ROOT="$DOKKU_ROOT/$APP"

--- a/subcommands/export-users
+++ b/subcommands/export-users
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+source "$PLUGIN_AVAILABLE_PATH/http-auth/command-functions"
+set -eo pipefail
+[[ $DOKKU_TRACE ]] && set -x
+
+cmd-http-auth-export-users "$@"

--- a/subcommands/import-users
+++ b/subcommands/import-users
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+source "$PLUGIN_AVAILABLE_PATH/http-auth/command-functions"
+set -eo pipefail
+[[ $DOKKU_TRACE ]] && set -x
+
+cmd-http-auth-import-users "$@"

--- a/tests/http_auth_export_import.bats
+++ b/tests/http_auth_export_import.bats
@@ -1,0 +1,165 @@
+#!/usr/bin/env bats
+
+load 'test_helper'
+
+setup() {
+  APP="$(new_app_name)"
+  create_app "$APP"
+  dokku http-auth:enable "$APP"
+}
+
+teardown() {
+  cleanup_app "$APP"
+}
+
+@test "(http-auth:export-users) streams htpasswd user:hash entries to stdout" {
+  dokku http-auth:add-user "$APP" u1 pass1
+  dokku http-auth:add-user "$APP" u2 pass2
+
+  local out
+  out="$(mktemp)"
+  run bash -c "dokku http-auth:export-users '$APP' >'$out'"
+  [ "$status" -eq 0 ]
+  grep -q '^u1:\$6\$' "$out"
+  grep -q '^u2:\$6\$' "$out"
+  [ "$(wc -l <"$out")" -eq 2 ]
+}
+
+@test "(http-auth:export-users) writes only the entries to stdout" {
+  dokku http-auth:add-user "$APP" u1 pass1
+
+  local out err
+  out="$(mktemp)"
+  err="$(mktemp)"
+  run bash -c "dokku http-auth:export-users '$APP' >'$out' 2>'$err'"
+  [ "$status" -eq 0 ]
+  # a clean stdout is what lets `export-users | import-users` work
+  [ "$(wc -l <"$out")" -eq 1 ]
+  grep -q '^u1:' "$out"
+}
+
+@test "(http-auth:export-users) still exports users when auth is disabled" {
+  dokku http-auth:add-user "$APP" u1 pass1
+  dokku http-auth:disable "$APP"
+
+  local out
+  out="$(mktemp)"
+  run bash -c "dokku http-auth:export-users '$APP' >'$out'"
+  [ "$status" -eq 0 ]
+  grep -q '^u1:\$6\$' "$out"
+}
+
+@test "(http-auth:export-users) warns and emits nothing when there are no users" {
+  local out err
+  out="$(mktemp)"
+  err="$(mktemp)"
+  run bash -c "dokku http-auth:export-users '$APP' >'$out' 2>'$err'"
+  [ "$status" -eq 0 ]
+  [ ! -s "$out" ]
+  grep -q "nothing to export" "$err"
+}
+
+@test "(http-auth:export-users) fails for a nonexistent app" {
+  run dokku http-auth:export-users hatest-no-such-app
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"does not exist"* ]]
+}
+
+@test "(http-auth:import-users) upserts imported users by default" {
+  dokku http-auth:add-user "$APP" u1 pass1
+
+  run dokku http-auth:import-users "$APP" <<< $'u2:hash2\nu3:hash3'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Importing 2 http-auth user(s)"* ]]
+
+  run dokku http-auth:report "$APP" --http-auth-users
+  [ "$status" -eq 0 ]
+  [ "$output" = "u1 u2 u3" ]
+}
+
+@test "(http-auth:import-users) upsert overrides an existing user and keeps the rest" {
+  dokku http-auth:add-user "$APP" u1 pass1
+  dokku http-auth:add-user "$APP" u2 pass2
+
+  run dokku http-auth:import-users "$APP" <<< 'u1:rehashed'
+  [ "$status" -eq 0 ]
+  [ "$(htpasswd_contents "$APP" | grep -c '^u1:')" -eq 1 ]
+  [ "$(htpasswd_contents "$APP" | grep '^u1:')" = "u1:rehashed" ]
+  htpasswd_contents "$APP" | grep -q '^u2:\$6\$'
+}
+
+@test "(http-auth:import-users --replace) replaces all users with the imported set" {
+  dokku http-auth:add-user "$APP" u1 pass1
+  dokku http-auth:add-user "$APP" u2 pass2
+
+  run dokku http-auth:import-users "$APP" --replace <<< 'u3:hash3'
+  [ "$status" -eq 0 ]
+
+  run dokku http-auth:report "$APP" --http-auth-users
+  [ "$status" -eq 0 ]
+  [ "$output" = "u3" ]
+}
+
+@test "(http-auth:import-users) enables auth when the app has it disabled" {
+  dokku http-auth:disable "$APP"
+  assert_disabled "$APP"
+
+  run dokku http-auth:import-users "$APP" <<< 'u1:hash1'
+  [ "$status" -eq 0 ]
+  assert_enabled "$APP"
+
+  run http_auth_conf "$APP"
+  [[ "$output" == *"auth_basic"* ]]
+}
+
+@test "(http-auth:import-users) rejects a malformed entry and leaves users unchanged" {
+  dokku http-auth:add-user "$APP" u1 pass1
+  local before
+  before="$(htpasswd_contents "$APP")"
+
+  run dokku http-auth:import-users "$APP" <<< 'not-an-entry'
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Invalid htpasswd entry"* ]]
+  [ "$(htpasswd_contents "$APP")" = "$before" ]
+}
+
+@test "(http-auth:import-users) fails when stdin has no entries" {
+  run dokku http-auth:import-users "$APP" </dev/null
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"No htpasswd entries provided on stdin"* ]]
+}
+
+@test "(http-auth:import-users) fails for a nonexistent app" {
+  run dokku http-auth:import-users hatest-no-such-app <<< 'u1:hash1'
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"does not exist"* ]]
+}
+
+@test "(http-auth:export-users) round-trips through import-users into another app" {
+  dokku http-auth:add-user "$APP" u1 pass1
+  dokku http-auth:add-user "$APP" u2 pass2
+
+  local out
+  out="$(mktemp)"
+  run bash -c "dokku http-auth:export-users '$APP' >'$out'"
+  [ "$status" -eq 0 ]
+
+  local app2
+  app2="$(new_app_name)"
+  create_app "$app2"
+  run bash -c "dokku http-auth:import-users '$app2' <'$out'"
+  local import_status="$status"
+
+  local users1 users2 contents1 contents2
+  users1="$(dokku http-auth:report "$APP" --http-auth-users)"
+  users2="$(dokku http-auth:report "$app2" --http-auth-users 2>/dev/null || true)"
+  contents1="$(htpasswd_contents "$APP")"
+  contents2="$(htpasswd_contents "$app2")"
+  cleanup_app "$app2"
+
+  [ "$import_status" -eq 0 ]
+  # export then re-import reproduces the same users and the same hashes
+  [ "$users1" = "u1 u2" ]
+  [ "$users1" = "$users2" ]
+  [ "$contents1" = "$contents2" ]
+}

--- a/tests/http_auth_help.bats
+++ b/tests/http_auth_help.bats
@@ -11,7 +11,7 @@ load 'test_helper'
 @test "(http-auth:help) lists every subcommand" {
   run dokku http-auth:help
   [ "$status" -eq 0 ]
-  for subcommand in add-allowed-ip add-domain add-user disable enable remove-allowed-ip remove-domain remove-user report set-domains show-config; do
+  for subcommand in add-allowed-ip add-domain add-user disable enable export-users import-users remove-allowed-ip remove-domain remove-user report set-domains show-config; do
     [[ "$output" == *"http-auth:${subcommand}"* ]]
   done
 }


### PR DESCRIPTION
These move http-auth credentials between hosts without exposing plaintext passwords. `http-auth:export-users` streams an app's htpasswd entries to stdout and `http-auth:import-users` applies entries from stdin, upserting by default or replacing the whole set with `--replace` and enabling auth.

Closes #37
