### PR TITLE
fix: let user management run while auth is disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ dokku http-auth:enable node-js-app username password
 
 ### Adding users
 
-Individual user/password combinations can be added at any point in time via the `http-auth:add-user` command. Specifying the same user twice will override the first instance of the user, even if the password is the same.
+Individual user/password combinations can be added at any point in time via the `http-auth:add-user` command. Specifying the same user twice will override the first instance of the user, even if the password is the same. Adding a user enables HTTP auth for the app if it was not already enabled.
 
 ```shell
 dokku http-auth:add-user node-js-app username password
@@ -85,7 +85,7 @@ dokku http-auth:add-user node-js-app username password
 
 ### Removing users
 
-A user can be removed via the `http-auth:remove-user` command. This command will always reload nginx, even if the user does not exist.
+A user can be removed via the `http-auth:remove-user` command. This command will always reload nginx, even if the user does not exist. It works whether or not auth is currently enabled and never turns auth back on, since removing a user is not a request to start authenticating.
 
 ```shell
 dokku http-auth:remove-user node-js-app username
@@ -281,6 +281,8 @@ All values are JSON strings, and list values (`allowed-ips`, `domains`, `users`)
 ### How state is persisted
 
 Whether HTTP auth is enabled for an app is tracked as an app property, and the generated nginx include (`nginx.conf.d/http-auth.conf`) is regenerated from that state on every deploy. This keeps the include in sync with the configured users and allowed IPs, and restores it automatically if it was ever left empty or out of date.
+
+The include is reconciled against that property on every change, not just on deploy: commands that add configuration (`add-user`, `add-allowed-ip`, `add-domain`, `set-domains`, `import-users`) enable auth and render the include, while commands that remove configuration leave the enabled state untouched. Removing configuration from a disabled app therefore leaves it disabled rather than putting auth back in front of nginx.
 
 ### Renaming, cloning, and destroying apps
 

--- a/command-functions
+++ b/command-functions
@@ -123,7 +123,6 @@ cmd-http-auth-enable() {
   fi
 
   declare APP="$1" AUTH_USERNAME="$2" AUTH_PASSWORD="$3"
-  local APP_ROOT="$DOKKU_ROOT/$APP"
 
   verify_app_name "$APP"
   if [[ "$(fn-http-auth-enabled "$APP")" == "true" ]]; then
@@ -139,7 +138,7 @@ cmd-http-auth-enable() {
   fi
 
   fn-plugin-property-write "http-auth" "$APP" "enabled" "true"
-  fn-http-auth-template-config "$APP"
+  fn-http-auth-sync-config "$APP"
   validate_nginx "$APP" && restart_nginx "$APP" >/dev/null
   dokku_log_verbose "Done"
 }
@@ -153,7 +152,6 @@ cmd-http-auth-disable() {
     shift 1
   fi
   declare APP="$1"
-  local APP_ROOT="$DOKKU_ROOT/$APP"
 
   verify_app_name "$APP"
   if [[ "$(fn-http-auth-enabled "$APP")" == "false" ]]; then
@@ -163,7 +161,7 @@ cmd-http-auth-disable() {
 
   dokku_log_info1 "Disabling HTTP auth for $APP..."
   fn-plugin-property-write "http-auth" "$APP" "enabled" "false"
-  rm -f "$APP_ROOT/nginx.conf.d/http-auth.conf"
+  fn-http-auth-sync-config "$APP"
   validate_nginx "$APP" && restart_nginx "$APP" >/dev/null
   dokku_log_verbose "Done"
 }
@@ -175,10 +173,6 @@ cmd-http-auth-add-user() {
   declare APP="$1" AUTH_USERNAME="$2" AUTH_PASSWORD="$3"
 
   verify_app_name "$APP"
-  if [[ "$(fn-http-auth-enabled "$APP")" == "false" ]]; then
-    dokku_log_fail "Authentication is disabled"
-    return 1
-  fi
 
   if [[ -z "$AUTH_USERNAME" ]]; then
     dokku_log_fail "Missing username"
@@ -192,7 +186,11 @@ cmd-http-auth-add-user() {
 
   dokku_log_info1 "Adding $AUTH_USERNAME to basic auth list"
   fn-http-auth-add-user "$APP" "$AUTH_USERNAME" "$AUTH_PASSWORD"
-  fn-http-auth-template-config "$APP"
+  # adding auth config turns auth on, matching add-allowed-ip/add-domain: disable
+  # leaves the htpasswd in place, so an app can have users while auth is off and
+  # managing them should not require enabling auth as a separate step first
+  fn-plugin-property-write "http-auth" "$APP" "enabled" "true"
+  fn-http-auth-sync-config "$APP"
   validate_nginx "$APP" && restart_nginx "$APP" >/dev/null
 }
 
@@ -219,7 +217,7 @@ cmd-http-auth-add-allowed-ip() {
   if fn-http-auth-has-auth-domains "$APP"; then
     fn-http-auth-warn-ip-domain-overlap
   fi
-  fn-http-auth-template-config "$APP"
+  fn-http-auth-sync-config "$APP"
   validate_nginx "$APP" && restart_nginx "$APP" >/dev/null
 }
 
@@ -230,10 +228,6 @@ cmd-http-auth-remove-user() {
   declare APP="$1" AUTH_USERNAME="$2"
 
   verify_app_name "$APP"
-  if [[ "$(fn-http-auth-enabled "$APP")" == "false" ]]; then
-    dokku_log_fail "Authentication is disabled"
-    return 1
-  fi
 
   if [[ -z "$AUTH_USERNAME" ]]; then
     dokku_log_fail "Missing username"
@@ -242,7 +236,9 @@ cmd-http-auth-remove-user() {
 
   dokku_log_info1 "Removing $AUTH_USERNAME from basic auth list"
   fn-http-auth-remove-user "$APP" "$AUTH_USERNAME"
-  fn-http-auth-template-config "$APP"
+  # unlike add-user, removing config never writes `enabled`: pruning a user must
+  # not turn auth on for an app the operator deliberately disabled
+  fn-http-auth-sync-config "$APP"
   validate_nginx "$APP" && restart_nginx "$APP" >/dev/null
 }
 
@@ -315,10 +311,9 @@ cmd-http-auth-import-users() {
 
   dokku_log_info1 "Importing ${#entries[@]} http-auth user(s) for $APP"
   printf '%s\n' "${entries[@]}" | fn-http-auth-import-users "$APP" "$REPLACE"
-  # adding auth config turns auth on, matching add-allowed-ip/add-domain, and
-  # guarantees the template render below never resurrects auth on a disabled app
+  # adding auth config turns auth on, matching add-user/add-allowed-ip/add-domain
   fn-plugin-property-write "http-auth" "$APP" "enabled" "true"
-  fn-http-auth-template-config "$APP"
+  fn-http-auth-sync-config "$APP"
   validate_nginx "$APP" && restart_nginx "$APP" >/dev/null
 }
 
@@ -337,7 +332,7 @@ cmd-http-auth-remove-allowed-ip() {
 
   dokku_log_info1 "Removing $ADDRESS from allowed ip list"
   fn-plugin-property-list-remove "http-auth" "$APP" "allowed-ips" "$ADDRESS"
-  fn-http-auth-template-config "$APP"
+  fn-http-auth-sync-config "$APP"
   validate_nginx "$APP" && restart_nginx "$APP" >/dev/null
 }
 
@@ -374,7 +369,7 @@ cmd-http-auth-add-domain() {
   if fn-http-auth-has-allowed-ips "$APP"; then
     fn-http-auth-warn-ip-domain-overlap
   fi
-  fn-http-auth-template-config "$APP"
+  fn-http-auth-sync-config "$APP"
   validate_nginx "$APP" && restart_nginx "$APP" >/dev/null
 }
 
@@ -394,7 +389,7 @@ cmd-http-auth-remove-domain() {
   DOMAIN="$(fn-http-auth-normalize-domain "$DOMAIN")"
   dokku_log_info1 "Removing $DOMAIN from auth domain list"
   fn-plugin-property-list-remove "http-auth" "$APP" "auth-domains" "$DOMAIN"
-  fn-http-auth-template-config "$APP"
+  fn-http-auth-sync-config "$APP"
   validate_nginx "$APP" && restart_nginx "$APP" >/dev/null
 }
 
@@ -434,6 +429,6 @@ cmd-http-auth-set-domains() {
     fi
   fi
 
-  fn-http-auth-template-config "$APP"
+  fn-http-auth-sync-config "$APP"
   validate_nginx "$APP" && restart_nginx "$APP" >/dev/null
 }

--- a/internal-functions
+++ b/internal-functions
@@ -147,6 +147,18 @@ fn-http-auth-template-config() {
   sigil -f "$DOKKU_TEMPLATE" HTPASSWD_PATH="$HTPASSWD_PATH" ALLOWED_IPS="$ALLOWED_IPS" AUTH_DOMAINS="$AUTH_DOMAINS" HAS_ALLOWED_USERS="$HAS_ALLOWED_USERS" | cat -s >"$APP_ROOT/nginx.conf.d/http-auth.conf"
 }
 
+fn-http-auth-sync-config() {
+  declare desc="render the app's nginx include when auth is enabled, remove it when disabled"
+  declare APP="$1"
+  local APP_ROOT="$DOKKU_ROOT/$APP"
+
+  if [[ "$(fn-http-auth-enabled "$APP")" == "true" ]]; then
+    fn-http-auth-template-config "$APP"
+  else
+    rm -f "$APP_ROOT/nginx.conf.d/http-auth.conf"
+  fi
+}
+
 fn-http-auth-app-vhosts() {
   declare desc="list the nginx vhosts currently attached to an app"
   declare APP="$1"

--- a/nginx-pre-reload
+++ b/nginx-pre-reload
@@ -8,13 +8,8 @@ trigger-http-auth-nginx-pre-reload() {
   declare desc="regenerates the http-auth nginx include whenever nginx config is rebuilt"
   declare trigger="nginx-pre-reload"
   declare APP="$1"
-  local APP_ROOT="$DOKKU_ROOT/$APP"
 
-  if [[ "$(fn-http-auth-enabled "$APP")" == "true" ]]; then
-    fn-http-auth-template-config "$APP"
-  else
-    rm -f "$APP_ROOT/nginx.conf.d/http-auth.conf"
-  fi
+  fn-http-auth-sync-config "$APP"
 }
 
 trigger-http-auth-nginx-pre-reload "$@"

--- a/post-app-clone-setup
+++ b/post-app-clone-setup
@@ -14,9 +14,7 @@ trigger-http-auth-post-app-clone-setup() {
     fn-http-auth-ensure-htpasswd "$OLD_APP"
     sudo "$(fn-http-auth-htpasswd-helper)" clone "$OLD_APP" "$NEW_APP"
   fi
-  if [[ "$(fn-http-auth-enabled "$NEW_APP")" == "true" ]]; then
-    fn-http-auth-template-config "$NEW_APP"
-  fi
+  fn-http-auth-sync-config "$NEW_APP"
 }
 
 trigger-http-auth-post-app-clone-setup "$@"

--- a/post-app-rename-setup
+++ b/post-app-rename-setup
@@ -15,9 +15,7 @@ trigger-http-auth-post-app-rename-setup() {
     fn-http-auth-ensure-htpasswd "$OLD_APP"
     sudo "$(fn-http-auth-htpasswd-helper)" rename "$OLD_APP" "$NEW_APP"
   fi
-  if [[ "$(fn-http-auth-enabled "$NEW_APP")" == "true" ]]; then
-    fn-http-auth-template-config "$NEW_APP"
-  fi
+  fn-http-auth-sync-config "$NEW_APP"
 }
 
 trigger-http-auth-post-app-rename-setup "$@"

--- a/tests/http_auth_allowed_ips.bats
+++ b/tests/http_auth_allowed_ips.bats
@@ -102,6 +102,18 @@ teardown() {
   [[ "$output" == *"allow 10.0.0.5;"* ]]
 }
 
+@test "(http-auth:remove-allowed-ip) on a disabled app does not resurrect the config" {
+  dokku http-auth:add-user "$APP" u1 pass1
+  dokku http-auth:add-allowed-ip "$APP" 10.0.0.7
+  dokku http-auth:disable "$APP"
+  run dokku http-auth:remove-allowed-ip "$APP" 10.0.0.7
+  [ "$status" -eq 0 ]
+  # the app still has users, so re-rendering the include would put auth back in
+  # front of nginx while the enabled property says otherwise
+  assert_disabled "$APP"
+  $SUDO test ! -f "$(http_auth_conf_path "$APP")"
+}
+
 @test "(http-auth:add-allowed-ip) warns when the app restricts auth to domains" {
   dokku domains:add "$APP" a.example.com >/dev/null
   dokku http-auth:add-domain "$APP" a.example.com

--- a/tests/http_auth_domains.bats
+++ b/tests/http_auth_domains.bats
@@ -155,6 +155,24 @@ teardown() {
   [[ "$output" != *'dokku_auth_realm'* ]]
 }
 
+@test "(http-auth:remove-domain) on a disabled app does not resurrect the config" {
+  dokku http-auth:add-domain "$APP" a.example.com
+  dokku http-auth:disable "$APP"
+  run dokku http-auth:remove-domain "$APP" a.example.com
+  [ "$status" -eq 0 ]
+  assert_disabled "$APP"
+  $SUDO test ! -f "$(http_auth_conf_path "$APP")"
+}
+
+@test "(http-auth:set-domains) with no domains on a disabled app does not resurrect the config" {
+  dokku http-auth:add-domain "$APP" a.example.com
+  dokku http-auth:disable "$APP"
+  run dokku http-auth:set-domains "$APP"
+  [ "$status" -eq 0 ]
+  assert_disabled "$APP"
+  $SUDO test ! -f "$(http_auth_conf_path "$APP")"
+}
+
 @test "(http-auth:remove-domain) fails when the domain is missing" {
   run dokku http-auth:remove-domain "$APP"
   [ "$status" -ne 0 ]

--- a/tests/http_auth_users.bats
+++ b/tests/http_auth_users.bats
@@ -4,12 +4,16 @@ load 'test_helper'
 
 setup() {
   APP="$(new_app_name)"
+  APP2=""
   create_app "$APP"
   dokku http-auth:enable "$APP"
 }
 
 teardown() {
   cleanup_app "$APP"
+  if [ -n "$APP2" ]; then
+    cleanup_app "$APP2"
+  fi
 }
 
 @test "(http-auth:add-user) adds an htpasswd entry with a sha-512 hash" {
@@ -35,11 +39,25 @@ teardown() {
   [ "$first_entry" != "$second_entry" ]
 }
 
-@test "(http-auth:add-user) fails when auth is disabled" {
+@test "(http-auth:add-user) on a disabled app enables auth" {
   dokku http-auth:disable "$APP"
+  assert_disabled "$APP"
   run dokku http-auth:add-user "$APP" u1 pass1
-  [ "$status" -ne 0 ]
-  [[ "$output" == *"Authentication is disabled"* ]]
+  [ "$status" -eq 0 ]
+  assert_enabled "$APP"
+  htpasswd_contents "$APP" | grep -q '^u1:\$6\$'
+  run http_auth_conf "$APP"
+  [[ "$output" == *"auth_basic"* ]]
+}
+
+@test "(http-auth:add-user) enables auth on an app that never had it enabled" {
+  APP2="$(new_app_name)"
+  create_app "$APP2"
+  run dokku http-auth:add-user "$APP2" u1 pass1
+  [ "$status" -eq 0 ]
+  assert_enabled "$APP2"
+  run http_auth_conf "$APP2"
+  [[ "$output" == *"auth_basic"* ]]
 }
 
 @test "(http-auth:add-user) fails when the username is missing" {
@@ -72,11 +90,15 @@ teardown() {
   [[ "$output" != *"auth_basic"* ]]
 }
 
-@test "(http-auth:remove-user) fails when auth is disabled" {
+@test "(http-auth:remove-user) prunes a user on a disabled app without enabling auth" {
+  dokku http-auth:add-user "$APP" u1 pass1
   dokku http-auth:disable "$APP"
   run dokku http-auth:remove-user "$APP" u1
-  [ "$status" -ne 0 ]
-  [[ "$output" == *"Authentication is disabled"* ]]
+  [ "$status" -eq 0 ]
+  # removing config must not turn auth back on, and must not resurrect the include
+  assert_disabled "$APP"
+  $SUDO test ! -f "$(http_auth_conf_path "$APP")"
+  [ -z "$(htpasswd_contents "$APP")" ]
 }
 
 @test "(http-auth:remove-user) fails when the username is missing" {


### PR DESCRIPTION
`http-auth:add-user` now enables auth as a side effect of adding credentials, matching `add-allowed-ip`, `add-domain`, `set-domains` and `import-users`, and `http-auth:remove-user` runs against a disabled app without turning auth back on. Every mutating command reconciles the nginx include against the app's enabled state through a single helper, so the removal commands no longer recreate `http-auth.conf` for an app whose auth is off.

Closes #40
